### PR TITLE
[codex] Add local browser login for favorites sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.0 - 2026-07-25
+
+- Adds a built-in Playwright collector for the signed-in user's Douyin favorites.
+- Adds `login`, `status`, and `logout` commands backed by an app-owned local browser profile.
+- Makes authorized browser collection the default `scan` source while preserving JSON and custom adapters.
+- Opens normal Douyin login when needed without accepting or printing raw cookies.
+- Adds browser orchestration tests and fail-closed handling for login, response, and pagination failures.
+
 ## 1.0.0 - 2026-07-25
 
 - First public release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,4 +9,4 @@ python3 -m compileall -q src tests
 PYTHONPATH=src python3 -m unittest discover -s tests -v
 ```
 
-Use synthetic fixtures only. A PR must include expected exit codes for new failure cases and must not add credentials, personal paths, real favorite exports, browser state, or notification targets.
+Use synthetic fixtures and mocked browser responses only. A PR must include expected exit codes for new failure cases and must not add credentials, personal paths, real favorite exports, browser state, or notification targets.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Douyin Favorites to Knowledge
 
-A small, transactional public core for turning authorized Douyin favorite metadata into reviewed local Markdown notes.
+Turn your authorized Douyin favorites into reviewed local Markdown notes. The built-in browser collector handles first-run login without asking you to copy or configure cookies.
 
 [![CI](https://github.com/tars1230/douyin-favorites-to-knowledge/actions/workflows/ci.yml/badge.svg)](https://github.com/tars1230/douyin-favorites-to-knowledge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 
-This repository is the reusable transaction layer, not a bundled login bypass or private browser automation. A real collector is an explicit adapter supplied by the user in an authorized environment.
+This project accesses only the favorites of the account that you explicitly sign into. It does not bypass login or platform access controls.
 
 ## Design
 
 ```text
-authorized export or collector adapter
+authorized browser session, export, or adapter
               |
               v
         scan -> review.json
@@ -35,11 +35,45 @@ python3 -m venv .venv
 python -m pip install .
 ```
 
+Chrome or Edge is used when available. If neither is installed, install Playwright Chromium once:
+
+```bash
+python -m playwright install chromium
+```
+
 Install the Agent Skill separately when needed:
 
 ```bash
 cp -R skill ~/.codex/skills/douyin-favorites-to-knowledge
 ```
+
+## First sync
+
+Create a config from [config/config.example.json](config/config.example.json), then run `scan`. On the first run, a local browser opens for normal Douyin login. Later runs reuse that app-owned browser session.
+
+```bash
+douyin-favorites-knowledge --config config/config.example.json scan \
+  --review .runtime/review.json
+
+douyin-favorites-knowledge --config config/config.example.json review \
+  --review .runtime/review.json \
+  --approve-all \
+  --approval .runtime/approval.json
+
+douyin-favorites-knowledge --config config/config.example.json promote \
+  --review .runtime/review.json \
+  --approval .runtime/approval.json
+```
+
+The login can also be managed explicitly:
+
+```bash
+douyin-favorites-knowledge login
+douyin-favorites-knowledge status
+douyin-favorites-knowledge logout
+```
+
+`login`, `status`, and `logout` never print cookie values or require a config file. For unattended jobs, add `--no-login-prompt` to `scan` so an expired session fails instead of opening a browser.
 
 ## Quick fixture E2E
 
@@ -85,6 +119,16 @@ The input is a JSON list, or an object with an `items` list. Each item accepts:
 
 Unknown source fields are not copied into notes. Query parameters, cookies, and collector-specific metadata therefore do not leak through by default.
 
+## Browser privacy
+
+- Login happens on Douyin's website in a dedicated local browser profile.
+- Raw cookies are not accepted as CLI arguments or config fields and are never written to review files or notes.
+- The default profile is stored under the operating system's application-state directory, outside the repository.
+- `logout` clears the saved browser session. Uninstalling the Python package does not silently delete user data.
+- Douyin can expire a session or change its private web response shape. The collector fails closed and asks for login or an update instead of treating that failure as an empty collection.
+
+Use `DOUYIN_FAVORITES_PROFILE_DIR` only when you need to relocate the app-owned profile. Do not point it at a daily browser profile or a broad directory.
+
 ## Adapters
 
 Use `module:function` specs:
@@ -100,7 +144,7 @@ def notifier(event: dict, config: dict) -> None:
     ...
 ```
 
-The public config accepts output paths only and rejects secret-like keys. Adapters must read credentials from their host environment or secret manager. The notifier runs after commit, so a notifier error means local promotion may already be complete.
+The config accepts output paths only and rejects secret-like keys. Adapters must read credentials from their host environment or secret manager. The notifier runs after commit, so a notifier error means local promotion may already be complete.
 
 ## Safety gates
 
@@ -139,10 +183,11 @@ CI also installs the built wheel into a fresh virtual environment and runs the f
 ## Uninstall
 
 ```bash
+douyin-favorites-knowledge logout
 python -m pip uninstall douyin-favorites-to-knowledge
 ```
 
-Uninstalling the package intentionally does not delete your configured knowledge directory or SQLite ledger. Remove those data paths only after backing them up and verifying the exact config target.
+Uninstalling the package intentionally does not delete your configured knowledge directory, SQLite ledger, or browser profile. Remove those data paths only after backing them up and verifying the exact target.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,8 @@
 
 Use GitHub private vulnerability reporting. Do not open a public issue with cookies, browser profiles, tokens, private favorite exports, generated personal notes, or production configuration.
 
-The public package accepts no credential fields. Collector, enricher, and notifier adapters must obtain secrets from their host's environment or secret manager and must avoid returning them in item data or errors.
+The package accepts no credential fields. The built-in collector stores Douyin session state only in an app-owned local browser profile and never emits cookie values. Do not point `DOUYIN_FAVORITES_PROFILE_DIR` at a daily browser profile, shared directory, or repository. Use `douyin-favorites-knowledge logout` to clear the saved session.
+
+Collector, enricher, and notifier adapters must obtain secrets from their host's environment or secret manager and must avoid returning them in item data or errors.
 
 Reasoning-tag and token-pattern checks are defense in depth, not a complete data-loss-prevention system. Review the generated manifest before approval and keep real review/approval artifacts outside the repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "douyin-favorites-to-knowledge"
-version = "1.0.0"
-description = "Transactional, adapter-based pipeline for promoting reviewed Douyin favorites into local knowledge notes"
+version = "1.1.0"
+description = "Authorized browser collection and transactional promotion of Douyin favorites into local knowledge notes"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [{name = "Cheng Chen"}]
-dependencies = []
+dependencies = ["playwright>=1.50,<2"]
 
 [project.scripts]
 douyin-favorites-knowledge = "douyin_favorites_knowledge.cli:main"

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,33 +1,33 @@
 ---
 name: douyin-favorites-to-knowledge
-description: Convert authorized Douyin favorite metadata into reviewed, idempotent local Markdown knowledge notes through an explicit scan, review, and promote transaction. Use when a user wants a reproducible favorites-to-knowledge workflow; do not use to bypass login, scrape accounts without authorization, or publish private data.
+description: Collect an authorized user's Douyin favorites through a locally managed browser login, then review and idempotently promote them into Markdown knowledge notes. Use for first-time login, incremental favorites sync, JSON import, review, or local knowledge-base promotion; do not use to bypass login, access another account, or publish private data.
 ---
 
 # Douyin Favorites to Knowledge
 
-Use the packaged CLI as the public transaction core. Collection, enrichment, and notification are explicit adapters; this Skill never assumes a browser profile, token, Feishu target, personal directory, or live production database.
+Use the packaged CLI. Prefer its built-in browser collector; use JSON or custom adapters only when the user already has an authorized export or integration. Never ask the user to paste cookies.
 
 ## Preconditions
 
 - The user is authorized to access the source favorites.
 - The collector complies with the platform terms and local law.
-- Credentials stay in the adapter host's environment or secret store.
+- Browser state stays in the app-owned local profile; never print or export it.
+- Adapter credentials stay in the host environment or secret store.
 - The JSON config contains only output paths; secret-like keys are rejected.
 
 ## Transaction
 
 ### 1. Scan
 
-Create a candidate review manifest without changing notes or the ledger:
+Create a candidate review manifest without changing notes or the ledger. With no source flag, `scan` uses the built-in browser collector. The first run opens Douyin for normal login and later runs reuse that local session:
 
 ```bash
-douyin-favorites-knowledge --config config.json scan \
-  --input favorites.json \
-  --source-label authorized_export \
-  --review review.json
+douyin-favorites-knowledge --config config.json scan --review review.json
 ```
 
-For a real collector, replace `--input` with `--collector module:function`. The collector receives the non-secret config object and returns iterable item objects. Add `--enricher module:function` only when enrichment is independently authorized.
+For unattended runs, add `--no-login-prompt` so an expired login fails closed. Use `douyin-favorites-knowledge login`, `status`, or `logout` to manage the app-owned session explicitly. These commands do not need `--config`.
+
+For an authorized export, add `--input favorites.json`. For a custom integration, add `--collector module:function`. The collector receives the non-secret config object and returns iterable item objects. Add `--enricher module:function` only when enrichment is independently authorized.
 
 ### 2. Review
 
@@ -81,10 +81,17 @@ def notifier(event: dict, config: dict) -> None: ...
 
 The notifier runs after the local transaction commits. A notification failure does not mean the notes were rolled back; inspect the command error, then notify again without re-promoting changed data.
 
+## Browser boundary
+
+- Allow login only on the official Douyin page opened by the CLI.
+- Do not request, display, log, or store raw cookies outside the browser profile.
+- Treat `login_required`, response-shape changes, and stalled pagination as blocking failures, not empty success.
+- Do not point `DOUYIN_FAVORITES_PROFILE_DIR` at a daily browser profile or broad directory.
+
 ## Verification
 
 ```bash
 python3 -m unittest discover -s tests -v
 ```
 
-Fixture success proves the public transaction core, not the availability or authorization of a third-party collector.
+Fixture success proves the transaction and browser orchestration contracts. Live collection still depends on an authorized Douyin session and the platform's current web behavior.

--- a/skill/agents/openai.yaml
+++ b/skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Douyin Favorites to Knowledge"
-  short_description: "Review and promote authorized favorites into local notes"
-  default_prompt: "Use $douyin-favorites-to-knowledge to scan, review, and promote authorized favorite metadata without exposing credentials."
+  short_description: "Sync signed-in Douyin favorites into reviewed local notes"
+  default_prompt: "Use $douyin-favorites-to-knowledge to sign in locally, scan my authorized favorites, review them, and promote approved notes without exposing cookies."

--- a/src/douyin_favorites_knowledge/__init__.py
+++ b/src/douyin_favorites_knowledge/__init__.py
@@ -1,3 +1,3 @@
 """Public core for reviewed Douyin-favorite knowledge promotion."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/src/douyin_favorites_knowledge/browser_collector.py
+++ b/src/douyin_favorites_knowledge/browser_collector.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import platform
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+COLLECTION_PAGE_URL = "https://www.douyin.com/user/self?showTab=favorite_collection"
+COLLECTION_API_URL = "https://www.douyin.com/aweme/v1/web/aweme/listcollection/"
+SESSION_COOKIE_NAMES = frozenset({"sessionid", "sessionid_ss", "sid_guard"})
+AWEME_ID = re.compile(r"^[0-9]{6,30}$")
+
+
+def default_profile_dir() -> Path:
+    override = os.environ.get("DOUYIN_FAVORITES_PROFILE_DIR")
+    if override:
+        return Path(override).expanduser().resolve()
+    system = platform.system()
+    if system == "Darwin":
+        root = Path.home() / "Library" / "Application Support"
+    elif system == "Windows":
+        root = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    else:
+        root = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state"))
+    return root / "douyin-favorites-to-knowledge" / "browser-profile"
+
+
+def _source_item(raw: dict[str, Any], observed_at: str) -> dict[str, Any] | None:
+    aweme_id = str(raw.get("aweme_id") or "").strip()
+    if not AWEME_ID.fullmatch(aweme_id):
+        return None
+    description = str(raw.get("description") or raw.get("desc") or "").strip()
+    title = description.splitlines()[0].strip() if description else ""
+    if not title:
+        title = f"Douyin favorite {aweme_id}"
+    return {
+        "aweme_id": aweme_id,
+        "title": title,
+        "author": str(raw.get("author") or "").strip(),
+        "description": description,
+        "transcript": "",
+        "tags": [],
+        "observed_at": observed_at,
+    }
+
+
+class BrowserCollector:
+    def __init__(self, profile_dir: Path | None = None, channel: str | None = None):
+        self.profile_dir = (profile_dir or default_profile_dir()).expanduser().resolve()
+        self.channel = channel
+        self._playwright = None
+        self._context = None
+        self._page = None
+
+    async def open(self, *, headless: bool) -> None:
+        try:
+            from playwright.async_api import async_playwright
+        except ImportError as exc:
+            raise ValueError(
+                "browser support is not installed; install the package with its browser dependencies"
+            ) from exc
+
+        self.profile_dir.mkdir(parents=True, exist_ok=True)
+        self._playwright = await async_playwright().start()
+        channels = [self.channel] if self.channel else ["chrome", "msedge", None]
+        for channel in channels:
+            kwargs: dict[str, Any] = {
+                "user_data_dir": str(self.profile_dir),
+                "headless": headless,
+                "viewport": {"width": 1280, "height": 800},
+                "locale": "zh-CN",
+            }
+            if channel:
+                kwargs["channel"] = channel
+            try:
+                self._context = await self._playwright.chromium.launch_persistent_context(**kwargs)
+                break
+            except Exception:
+                self._context = None
+        if self._context is None:
+            await self._playwright.stop()
+            self._playwright = None
+            raise ValueError(
+                "no supported browser is available; install Chrome, Edge, or Playwright Chromium"
+            )
+        self._page = self._context.pages[0] if self._context.pages else await self._context.new_page()
+
+    async def close(self) -> None:
+        if self._context is not None:
+            await self._context.close()
+        if self._playwright is not None:
+            await self._playwright.stop()
+        self._context = None
+        self._playwright = None
+        self._page = None
+
+    async def navigate(self) -> None:
+        if self._page is None:
+            raise ValueError("browser is not open")
+        await self._page.goto(COLLECTION_PAGE_URL, wait_until="domcontentloaded", timeout=45_000)
+
+    async def authenticated(self) -> bool:
+        if self._context is None:
+            return False
+        cookies = await self._context.cookies("https://www.douyin.com")
+        return any(cookie.get("name") in SESSION_COOKIE_NAMES and cookie.get("value") for cookie in cookies)
+
+    async def clear_session(self) -> None:
+        if self._context is None:
+            raise ValueError("browser is not open")
+        await self._context.clear_cookies()
+        for page in self._context.pages:
+            try:
+                await page.evaluate("localStorage.clear(); sessionStorage.clear()")
+            except Exception:
+                continue
+
+    async def fetch_page(self, *, cursor: int, count: int) -> dict[str, Any]:
+        if self._page is None:
+            raise ValueError("browser is not open")
+        result = await self._page.evaluate(
+            """async ({apiUrl, cursor, count}) => {
+                const params = new URLSearchParams({
+                    device_platform: 'webapp',
+                    aid: '6383',
+                    channel: 'channel_pc_web',
+                    cookie_enabled: String(navigator.cookieEnabled),
+                    browser_language: navigator.language || 'zh-CN',
+                    browser_platform: navigator.platform || '',
+                    browser_name: 'Chrome',
+                });
+                const body = new URLSearchParams({count: String(count), cursor: String(cursor)});
+                const response = await fetch(apiUrl + '?' + params.toString(), {
+                    method: 'POST',
+                    credentials: 'include',
+                    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                    body: body.toString(),
+                });
+                if (!response.ok) {
+                    return {ok: false, http_status: response.status};
+                }
+                const data = await response.json();
+                return {
+                    ok: data.status_code === 0,
+                    status_code: data.status_code,
+                    cursor: Number(data.cursor || 0),
+                    has_more: Boolean(data.has_more),
+                    items: (data.aweme_list || []).map(item => ({
+                        aweme_id: String(item.aweme_id || ''),
+                        description: item.desc || '',
+                        author: item.author ? item.author.nickname || '' : '',
+                    })),
+                };
+            }""",
+            {"apiUrl": COLLECTION_API_URL, "cursor": cursor, "count": count},
+        )
+        if not isinstance(result, dict):
+            raise ValueError("Douyin returned an invalid collection response")
+        return result
+
+
+async def _login(*, timeout_seconds: int, channel: str | None) -> dict[str, Any]:
+    collector = BrowserCollector(channel=channel)
+    await collector.open(headless=False)
+    try:
+        await collector.navigate()
+        deadline = asyncio.get_running_loop().time() + timeout_seconds
+        while asyncio.get_running_loop().time() < deadline:
+            if await collector.authenticated():
+                result = await collector.fetch_page(cursor=0, count=1)
+                if result.get("ok"):
+                    return {"status": "authenticated"}
+            await asyncio.sleep(2)
+        raise ValueError("login was not completed before the timeout")
+    finally:
+        await collector.close()
+
+
+def login_browser(*, timeout_seconds: int = 300, channel: str | None = None) -> dict[str, Any]:
+    if timeout_seconds < 10:
+        raise ValueError("login timeout must be at least 10 seconds")
+    try:
+        return asyncio.run(_login(timeout_seconds=timeout_seconds, channel=channel))
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError("browser login failed; close the login window and retry") from exc
+
+
+async def _status(*, channel: str | None) -> dict[str, Any]:
+    collector = BrowserCollector(channel=channel)
+    await collector.open(headless=True)
+    try:
+        await collector.navigate()
+        if not await collector.authenticated():
+            return {"status": "login_required"}
+        result = await collector.fetch_page(cursor=0, count=1)
+        return {"status": "authenticated" if result.get("ok") else "login_required"}
+    finally:
+        await collector.close()
+
+
+def browser_status(*, channel: str | None = None) -> dict[str, Any]:
+    try:
+        return asyncio.run(_status(channel=channel))
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError("browser status check failed; close other sync processes and retry") from exc
+
+
+async def _logout(*, channel: str | None) -> dict[str, Any]:
+    collector = BrowserCollector(channel=channel)
+    await collector.open(headless=True)
+    try:
+        await collector.clear_session()
+        return {"status": "logged_out"}
+    finally:
+        await collector.close()
+
+
+def logout_browser(*, channel: str | None = None) -> dict[str, Any]:
+    try:
+        return asyncio.run(_logout(channel=channel))
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError("browser logout failed; close other sync processes and retry") from exc
+
+
+async def _collect(
+    *,
+    max_items: int,
+    interactive_login: bool,
+    headed: bool,
+    channel: str | None,
+) -> list[dict[str, Any]]:
+    collector = BrowserCollector(channel=channel)
+    await collector.open(headless=not headed)
+    try:
+        await collector.navigate()
+        if not await collector.authenticated():
+            await collector.close()
+            if not interactive_login:
+                raise ValueError("Douyin login is required; run the login command first")
+            await _login(timeout_seconds=300, channel=channel)
+            await collector.open(headless=not headed)
+            await collector.navigate()
+
+        observed_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        collected: dict[str, dict[str, Any]] = {}
+        cursor = 0
+        seen_cursors: set[int] = set()
+        while len(collected) < max_items:
+            page_size = min(20, max_items - len(collected))
+            result = await collector.fetch_page(cursor=cursor, count=page_size)
+            if not result.get("ok"):
+                raise ValueError("Douyin collection access failed; login again and retry")
+            items = result.get("items")
+            if not isinstance(items, list):
+                raise ValueError("Douyin returned an invalid collection item list")
+            for raw in items:
+                if not isinstance(raw, dict):
+                    continue
+                item = _source_item(raw, observed_at)
+                if item is not None:
+                    collected[item["aweme_id"]] = item
+                    if len(collected) >= max_items:
+                        break
+            if not result.get("has_more") or not items:
+                break
+            next_cursor = int(result.get("cursor") or 0)
+            if next_cursor in seen_cursors or next_cursor == cursor:
+                raise ValueError("Douyin collection pagination stopped advancing")
+            seen_cursors.add(cursor)
+            cursor = next_cursor
+            await asyncio.sleep(0.5)
+        return list(collected.values())
+    finally:
+        await collector.close()
+
+
+def collect_browser_favorites(
+    *,
+    max_items: int = 200,
+    interactive_login: bool = True,
+    headed: bool = False,
+    channel: str | None = None,
+) -> list[dict[str, Any]]:
+    if max_items < 1 or max_items > 10_000:
+        raise ValueError("max_items must be between 1 and 10000")
+    try:
+        return asyncio.run(
+            _collect(
+                max_items=max_items,
+                interactive_login=interactive_login,
+                headed=headed,
+                channel=channel,
+            )
+        )
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError("browser collection failed; close other sync processes and retry") from exc

--- a/src/douyin_favorites_knowledge/cli.py
+++ b/src/douyin_favorites_knowledge/cli.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 from .adapters import load_adapter
+from .browser_collector import browser_status, collect_browser_favorites, login_browser, logout_browser
 from .config import load_config
 from .security import safe_error_message
 from .workflow import (
@@ -21,16 +22,31 @@ from .workflow import (
 
 def parser() -> argparse.ArgumentParser:
     root = argparse.ArgumentParser(description="Promote reviewed Douyin favorites into local knowledge notes")
-    root.add_argument("--config", type=Path, required=True, help="Path to schema_version=1 JSON config")
+    root.add_argument("--config", type=Path, help="Path to schema_version=1 JSON config")
     commands = root.add_subparsers(dest="command", required=True)
 
+    login = commands.add_parser("login", help="Open a local browser and save an authorized session")
+    login.add_argument("--timeout", type=int, default=300, help="Seconds to wait for login")
+    login.add_argument("--browser-channel", help="Playwright channel such as chrome or msedge")
+
+    status = commands.add_parser("status", help="Check the saved browser session without exposing it")
+    status.add_argument("--browser-channel", help="Playwright channel such as chrome or msedge")
+
+    logout = commands.add_parser("logout", help="Clear the locally saved Douyin browser session")
+    logout.add_argument("--browser-channel", help="Playwright channel such as chrome or msedge")
+
     scan = commands.add_parser("scan", help="Create a non-mutating review manifest")
-    source = scan.add_mutually_exclusive_group(required=True)
+    source = scan.add_mutually_exclusive_group()
     source.add_argument("--input", type=Path, help="JSON list or object containing items")
     source.add_argument("--collector", help="Collector adapter in module:function format")
+    source.add_argument("--browser", action="store_true", help="Use the built-in authorized browser collector")
     scan.add_argument("--enricher", help="Optional per-item enricher adapter in module:function format")
-    scan.add_argument("--source-label", default="external", help="Non-sensitive source label stored in the manifest")
+    scan.add_argument("--source-label", help="Non-sensitive source label stored in the manifest")
     scan.add_argument("--review", type=Path, required=True, help="Review manifest output")
+    scan.add_argument("--max-items", type=int, default=200, help="Maximum browser items to collect")
+    scan.add_argument("--headed", action="store_true", help="Keep the collection browser visible")
+    scan.add_argument("--no-login-prompt", action="store_true", help="Fail instead of opening login")
+    scan.add_argument("--browser-channel", help="Playwright channel such as chrome or msedge")
     scan.add_argument("--dry-run", action="store_true", help="Validate and summarize without writing")
 
     review = commands.add_parser("review", help="Validate a review and optionally create explicit approval")
@@ -56,13 +72,38 @@ def _print(payload: dict) -> None:
 def main(argv: list[str] | None = None) -> int:
     args = parser().parse_args(argv)
     try:
+        if args.command == "login":
+            _print(login_browser(timeout_seconds=args.timeout, channel=args.browser_channel))
+            return 0
+
+        if args.command == "status":
+            result = browser_status(channel=args.browser_channel)
+            _print(result)
+            return 0 if result["status"] == "authenticated" else 1
+
+        if args.command == "logout":
+            _print(logout_browser(channel=args.browser_channel))
+            return 0
+
+        if args.config is None:
+            raise ValueError(f"--config is required for {args.command}")
         config = load_config(args.config)
         if args.command == "scan":
             if args.input:
                 raw_items = read_input(args.input)
-            else:
+                default_source_label = "authorized_export"
+            elif args.collector:
                 collector = load_adapter(args.collector)
                 raw_items = list(collector(dict(config.raw)))
+                default_source_label = "external_adapter"
+            else:
+                raw_items = collect_browser_favorites(
+                    max_items=args.max_items,
+                    interactive_login=not args.no_login_prompt,
+                    headed=args.headed,
+                    channel=args.browser_channel,
+                )
+                default_source_label = "authorized_browser"
             if args.enricher:
                 enricher = load_adapter(args.enricher)
                 enriched = []
@@ -72,7 +113,7 @@ def main(argv: list[str] | None = None) -> int:
                         raise ValueError("enricher must return an object")
                     enriched.append({**raw, **update})
                 raw_items = enriched
-            manifest = build_review(config, raw_items, args.source_label)
+            manifest = build_review(config, raw_items, args.source_label or default_source_label)
             result = {"status": "valid", **manifest["summary"], "review": str(args.review)}
             if not args.dry_run:
                 atomic_write_json(args.review, manifest)

--- a/tests/test_browser_collector.py
+++ b/tests/test_browser_collector.py
@@ -1,0 +1,124 @@
+import asyncio
+import os
+import unittest
+from unittest.mock import patch
+
+
+from douyin_favorites_knowledge import browser_collector
+
+
+class FakeCollector:
+    pages = [
+        {
+            "ok": True,
+            "cursor": 20,
+            "has_more": True,
+            "items": [
+                {"aweme_id": "7000000000000000001", "description": "First\nMore", "author": "A"},
+                {"aweme_id": "invalid", "description": "Ignored", "author": "B"},
+            ],
+        },
+        {
+            "ok": True,
+            "cursor": 40,
+            "has_more": False,
+            "items": [
+                {"aweme_id": "7000000000000000002", "description": "Second", "author": "C"}
+            ],
+        },
+    ]
+
+    def __init__(self, *args, **kwargs):
+        self.fetches = 0
+        self.closed = False
+
+    async def open(self, *, headless):
+        self.headless = headless
+
+    async def close(self):
+        self.closed = True
+
+    async def navigate(self):
+        return None
+
+    async def authenticated(self):
+        return True
+
+    async def fetch_page(self, *, cursor, count):
+        result = self.pages[self.fetches]
+        self.fetches += 1
+        return result
+
+
+class LoggedOutCollector(FakeCollector):
+    async def authenticated(self):
+        return False
+
+
+class BrowserCollectorTests(unittest.TestCase):
+    def test_default_profile_override_is_not_returned_by_status(self):
+        with patch.dict(os.environ, {"DOUYIN_FAVORITES_PROFILE_DIR": "./private-browser-state"}):
+            path = browser_collector.default_profile_dir()
+        self.assertEqual(path.name, "private-browser-state")
+
+    def test_source_item_keeps_only_supported_metadata(self):
+        item = browser_collector._source_item(
+            {
+                "aweme_id": "7000000000000000001",
+                "description": "Title\nDescription",
+                "author": "Creator",
+                "sessionid": "must-not-leak",
+                "statistics": {"secret": "must-not-leak"},
+            },
+            "2026-07-25T00:00:00+00:00",
+        )
+        self.assertEqual(
+            set(item),
+            {"aweme_id", "title", "author", "description", "transcript", "tags", "observed_at"},
+        )
+        self.assertNotIn("must-not-leak", str(item))
+
+    def test_collection_paginates_and_filters_invalid_ids(self):
+        with patch.object(browser_collector, "BrowserCollector", FakeCollector):
+            items = asyncio.run(
+                browser_collector._collect(
+                    max_items=10,
+                    interactive_login=False,
+                    headed=False,
+                    channel=None,
+                )
+            )
+        self.assertEqual([item["aweme_id"] for item in items], [
+            "7000000000000000001",
+            "7000000000000000002",
+        ])
+        self.assertEqual(items[0]["title"], "First")
+
+    def test_invalid_item_limit_is_rejected_before_browser_start(self):
+        with self.assertRaisesRegex(ValueError, "between 1 and 10000"):
+            browser_collector.collect_browser_favorites(max_items=0)
+
+    def test_expired_login_is_not_treated_as_empty_collection(self):
+        with patch.object(browser_collector, "BrowserCollector", LoggedOutCollector):
+            with self.assertRaisesRegex(ValueError, "login is required"):
+                asyncio.run(
+                    browser_collector._collect(
+                        max_items=10,
+                        interactive_login=False,
+                        headed=False,
+                        channel=None,
+                    )
+                )
+
+    def test_browser_errors_are_replaced_with_stable_message(self):
+        async def fail(**kwargs):
+            raise RuntimeError("private profile path and session detail")
+
+        with patch.object(browser_collector, "_status", fail):
+            with self.assertRaisesRegex(ValueError, "browser status check failed") as raised:
+                browser_collector.browser_status()
+        self.assertNotIn("private profile", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -8,6 +8,12 @@ TEXT_SUFFIXES = {".md", ".py", ".json", ".yml", ".yaml", ".toml", ".txt"}
 
 
 class RepositoryTests(unittest.TestCase):
+    def test_version_is_current_release(self):
+        text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        self.assertIn('version = "1.1.0"', text)
+        package = (ROOT / "src" / "douyin_favorites_knowledge" / "__init__.py").read_text(encoding="utf-8")
+        self.assertIn('__version__ = "1.1.0"', package)
+
     def test_skill_frontmatter(self):
         text = (ROOT / "skill" / "SKILL.md").read_text(encoding="utf-8")
         self.assertTrue(text.startswith("---\n"))

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -5,7 +5,10 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from pathlib import Path
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -14,6 +17,7 @@ PYTHONPATH = str(ROOT / "src")
 sys.path.insert(0, PYTHONPATH)
 
 from douyin_favorites_knowledge.security import safe_error_message  # noqa: E402
+from douyin_favorites_knowledge.cli import main  # noqa: E402
 
 
 def cli(config: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -198,6 +202,65 @@ class WorkflowTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertFalse(self.review.exists())
         self.assertFalse(self.ledger.exists())
+
+    def test_scan_defaults_to_authorized_browser_collector(self):
+        source_items = json.loads(FIXTURE.read_text(encoding="utf-8"))["items"]
+        output = StringIO()
+        with patch(
+            "douyin_favorites_knowledge.cli.collect_browser_favorites",
+            return_value=source_items,
+        ) as collect, redirect_stdout(output):
+            returncode = main(
+                [
+                    "--config",
+                    str(self.config),
+                    "scan",
+                    "--review",
+                    str(self.review),
+                    "--max-items",
+                    "7",
+                    "--no-login-prompt",
+                ]
+            )
+        self.assertEqual(returncode, 0)
+        collect.assert_called_once_with(
+            max_items=7,
+            interactive_login=False,
+            headed=False,
+            channel=None,
+        )
+        review = json.loads(self.review.read_text(encoding="utf-8"))
+        self.assertEqual(review["source_label"], "authorized_browser")
+
+    def test_login_does_not_require_config_or_expose_session_details(self):
+        output = StringIO()
+        with patch(
+            "douyin_favorites_knowledge.cli.login_browser",
+            return_value={"status": "authenticated"},
+        ), redirect_stdout(output):
+            returncode = main(["login", "--timeout", "30"])
+        self.assertEqual(returncode, 0)
+        self.assertEqual(json.loads(output.getvalue()), {"status": "authenticated"})
+
+    def test_status_returns_nonzero_when_login_is_required(self):
+        output = StringIO()
+        with patch(
+            "douyin_favorites_knowledge.cli.browser_status",
+            return_value={"status": "login_required"},
+        ), redirect_stdout(output):
+            returncode = main(["status"])
+        self.assertEqual(returncode, 1)
+        self.assertEqual(json.loads(output.getvalue()), {"status": "login_required"})
+
+    def test_logout_clears_session_without_requiring_config(self):
+        output = StringIO()
+        with patch(
+            "douyin_favorites_knowledge.cli.logout_browser",
+            return_value={"status": "logged_out"},
+        ), redirect_stdout(output):
+            returncode = main(["logout"])
+        self.assertEqual(returncode, 0)
+        self.assertEqual(json.loads(output.getvalue()), {"status": "logged_out"})
 
     def test_secret_like_config_key_is_rejected(self):
         payload = json.loads(self.config.read_text(encoding="utf-8"))


### PR DESCRIPTION
## What changed

- Add a built-in Playwright collector for the signed-in user's Douyin favorites.
- Add `login`, `status`, and `logout` commands using an app-owned browser profile.
- Make browser collection the default `scan` source while preserving JSON and custom adapters.
- Keep raw cookies out of CLI arguments, config, review manifests, notes, logs, and repository files.
- Add mocked browser tests, fail-closed login/pagination handling, updated Skill metadata, and v1.1.0 documentation.

## Why

The public repository previously shipped only the transaction core, so a downloader had to provide a collector adapter. This release closes that usability gap without asking users to copy cookies or exposing private browser state.

## Validation

- 21 local unit and integration tests pass.
- `skill-creator` validation passes.
- Fresh virtualenv install and fixture `scan -> review -> promote` pass.
- Existing authorized account preflight: 10 collections accessible.
- Isolated managed-profile live check: `status=authenticated`; default scan dry-run returns 5 candidates.
