### PR TITLE
[codex] 中文页面与可选处理模式

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           python -m venv /tmp/dftk-venv
           /tmp/dftk-venv/bin/pip install .
           /tmp/dftk-venv/bin/douyin-favorites-knowledge --help
+          /tmp/dftk-venv/bin/douyin-favorites-knowledge --config config/config.example.json check-config
           /tmp/dftk-venv/bin/douyin-favorites-knowledge --config config/config.example.json scan --input tests/fixtures/favorites.json --source-label ci_fixture --review .runtime/review.json
           /tmp/dftk-venv/bin/douyin-favorites-knowledge --config config/config.example.json review --review .runtime/review.json --approve-all --approval .runtime/approval.json
           /tmp/dftk-venv/bin/douyin-favorites-knowledge --config config/config.example.json promote --review .runtime/review.json --approval .runtime/approval.json --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
           python -m venv /tmp/dftk-venv
           /tmp/dftk-venv/bin/pip install .
           /tmp/dftk-venv/bin/douyin-favorites-knowledge --help
+          DOUYIN_FAVORITES_CONFIG=/tmp/dftk-onboarding-config.json /tmp/dftk-venv/bin/douyin-favorites-knowledge setup --knowledge-dir /tmp/dftk-onboarding-notes --skip-login
+          DOUYIN_FAVORITES_CONFIG=/tmp/dftk-onboarding-config.json /tmp/dftk-venv/bin/douyin-favorites-knowledge check-config
           /tmp/dftk-venv/bin/douyin-favorites-knowledge --config config/config.example.json check-config
           /tmp/dftk-venv/bin/douyin-favorites-knowledge --config config/config.example.json scan --input tests/fixtures/favorites.json --source-label ci_fixture --review .runtime/review.json
           /tmp/dftk-venv/bin/douyin-favorites-knowledge --config config/config.example.json review --review .runtime/review.json --approve-all --approval .runtime/approval.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 .DS_Store
 .venv/
 .runtime/
+config/config.local.json
 build/
 dist/
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -48,11 +48,50 @@
 
 ## 安装
 
+第一次使用请直接选择轻量模式。确认收藏能正常写入 Markdown 后，再考虑本地转录、MiniMax 或飞书通知。
+
+### 1. 下载项目
+
+安装了 Git 时运行：
+
+```bash
+git clone https://github.com/tars1230/douyin-favorites-to-knowledge.git
+cd douyin-favorites-to-knowledge
+```
+
+没有 Git 也可以在 GitHub 页面点击 **Code -> Download ZIP**，解压后在终端进入该目录。
+
+### 2. 创建 Python 环境
+
+需要 Python 3.10 或更高版本，先确认版本：
+
+```bash
+python3 --version
+```
+
+macOS / Linux：
+
 ```bash
 python3 -m venv .venv
 . .venv/bin/activate
 python -m pip install .
 ```
+
+Windows PowerShell：
+
+```powershell
+py -3 -m venv .venv
+.venv\Scripts\Activate.ps1
+python -m pip install .
+```
+
+安装完成后，这条命令应能显示帮助：
+
+```bash
+douyin-favorites-knowledge --help
+```
+
+### 3. 准备浏览器
 
 系统会优先使用 Chrome 或 Edge。两者都没有时，安装一次 Playwright Chromium：
 
@@ -60,15 +99,31 @@ python -m pip install .
 python -m playwright install chromium
 ```
 
-需要在 Codex 中调用 Skill 时，再安装 Skill 目录：
+### 4. 可选安装 Codex Skill
+
+只使用命令行时可以跳过。需要在 Codex 中调用本项目时再安装：
 
 ```bash
 cp -R skill ~/.codex/skills/douyin-favorites-to-knowledge
 ```
 
-## 轻量模式快速开始
+## 第一次入库
 
-复制 [config/config.example.json](config/config.example.json) 后修改知识库位置。默认配置已经是轻量模式：
+### 1. 创建自己的配置
+
+不要直接修改示例文件。macOS / Linux：
+
+```bash
+cp config/config.example.json config/config.local.json
+```
+
+Windows PowerShell：
+
+```powershell
+Copy-Item config/config.example.json config/config.local.json
+```
+
+`config/config.local.json` 已加入 `.gitignore`，不会被意外提交。默认配置已经是轻量模式：
 
 ```json
 {
@@ -82,26 +137,83 @@ cp -R skill ~/.codex/skills/douyin-favorites-to-knowledge
 }
 ```
 
-第一次扫描会打开浏览器，正常登录抖音即可：
+只需要先修改 `knowledge_dir`：
+
+- 普通 Markdown 知识库：填写你准备存放笔记的目录；
+- Obsidian：填写 Vault 里的一个独立子目录；
+- 相对路径以配置文件所在目录为基准，也可以使用绝对路径；
+- `ledger_path` 是防重复入库的本地账本，通常保持默认即可。
+
+### 2. 检查配置
 
 ```bash
-douyin-favorites-knowledge --config config/config.example.json scan \
-  --review .runtime/review.json
+douyin-favorites-knowledge --config config/config.local.json check-config
+```
 
-douyin-favorites-knowledge --config config/config.example.json review \
+首次使用应看到类似结果：
+
+```json
+{
+  "mode": "light",
+  "schema_version": 2,
+  "stages": {
+    "analysis": {"enabled": false, "provider": "none"},
+    "notification": {"enabled": false, "provider": "none"},
+    "transcription": {"enabled": false, "provider": "none"}
+  },
+  "status": "valid"
+}
+```
+
+这条命令不会输出 Cookie、配置路径、知识库路径或 adapter 名称。注意：`--config` 必须写在 `check-config`、`scan`、`review`、`promote` 等子命令之前。
+
+### 3. 登录抖音
+
+```bash
+douyin-favorites-knowledge login
+```
+
+浏览器会打开抖音官方页面。正常登录后，终端返回 `authenticated`。后续运行会复用这个独立本地会话。
+
+### 4. 扫描新增收藏
+
+```bash
+douyin-favorites-knowledge --config config/config.local.json scan \
+  --review .runtime/review.json
+```
+
+返回 `status: written` 表示待审核清单已经生成。`candidate_count` 是本次等待审核的新增数量；为 `0` 时不会生成可批准内容。
+
+### 5. 批准并写入知识库
+
+确认 review 内容后批准全部条目：
+
+```bash
+douyin-favorites-knowledge --config config/config.local.json review \
   --review .runtime/review.json \
   --approve-all \
   --approval .runtime/approval.json
 
-douyin-favorites-knowledge --config config/config.example.json promote \
+douyin-favorites-knowledge --config config/config.local.json promote \
   --review .runtime/review.json \
   --approval .runtime/approval.json
 ```
 
-也可以单独管理登录状态：
+返回 `status: committed` 后，打开 `knowledge_dir`：每条批准收藏应有一份 `.md` 文件。再次运行同一批内容时，`promoted_count` 为 `0`，不会重复入库。
+
+需要只批准部分内容时，不使用 `--approve-all`，改为重复指定 ID：
 
 ```bash
-douyin-favorites-knowledge login
+douyin-favorites-knowledge --config config/config.local.json review \
+  --review .runtime/review.json \
+  --approve 7000000000000000001 \
+  --approve 7000000000000000002 \
+  --approval .runtime/approval.json
+```
+
+登录状态管理：
+
+```bash
 douyin-favorites-knowledge status
 douyin-favorites-knowledge logout
 ```
@@ -110,7 +222,14 @@ douyin-favorites-knowledge logout
 
 ## 完整模式配置
 
-下面只展示结构。adapter 名称和模型名要替换成你电脑上实际可用的实现：
+完整模式是进阶功能。启用前先确认：
+
+1. 轻量模式已经成功完成一次入库；
+2. 对应 adapter 已安装在当前虚拟环境，能通过 `module:function` 导入；
+3. 本地模型或云端模型名称真实可用；
+4. API key、飞书密钥等已经放进环境变量、系统钥匙串或 Secret Manager。
+
+下面只展示结构。adapter 名称和模型名必须替换成当前电脑上真实可用的实现：
 
 ```json
 {
@@ -139,6 +258,8 @@ douyin-favorites-knowledge logout
 ```
 
 每个阶段都可以独立关闭或换成 `adapter`。使用本地模型时，`model` 写本机实际模型；使用 MiniMax 时，`model` 写账号可用模型。API key、飞书密钥和其他凭据只允许从环境变量、系统钥匙串或宿主 Secret Manager 读取，配置文件中的 secret、token、password、cookie、credential 和 API key 类字段会被拒绝。
+
+修改后再次运行 `check-config`。它只验证配置契约；adapter 能否连接模型或飞书，仍要由对应 adapter 自己提供连接测试。
 
 ## Adapter 契约
 
@@ -188,6 +309,21 @@ douyin-favorites-knowledge --config config.json promote \
 | `observed_at` | 否 | 采集时间 |
 
 输出是普通 Markdown 文件，因此 `knowledge_dir` 可以直接指向 Obsidian Vault 中的一个独立目录。项目不修改 Obsidian 设置，也不要求安装 Obsidian 插件。
+
+## 常见问题
+
+| 现象 | 怎么处理 |
+|---|---|
+| `--config is required` | 把 `--config config/config.local.json` 放在子命令前面 |
+| `config ... must` 或 `unknown config fields` | 先对照示例恢复字段，再运行 `check-config` |
+| `secret-like key blocked` | 从 JSON 删除密钥、Cookie 或 token，改从环境变量或密钥管理器读取 |
+| 找不到 Chrome、Edge 或 Chromium | 运行 `python -m playwright install chromium` |
+| 返回 `login_required` | 运行 `douyin-favorites-knowledge login` 重新登录 |
+| `candidate_count` 为 `0` | 当前没有未入库的新收藏；这不是错误 |
+| 完整模式提示缺少 `adapter` 或 `model` | 暂时切回 `light`，或先安装并验证对应 adapter 和模型 |
+| adapter 连接 MiniMax、飞书或本地模型失败 | 检查该 adapter 的环境变量、模型名称和连接测试；核心不会读取其凭据 |
+
+仍无法判断时，依次保留 `check-config` 输出、执行命令和脱敏后的 `ERROR:` 文本。不要提交浏览器 profile、Cookie 或配置外的密钥文件。
 
 ## 隐私与安全边界
 

--- a/README.md
+++ b/README.md
@@ -1,83 +1,67 @@
 # 抖音收藏转本地知识库
 
-把自己账号里新增的抖音收藏，整理成经过审核、可重复运行的本地 Markdown 知识笔记。首次使用会打开抖音官方页面登录，之后复用独立的本地浏览器会话；不用复制 Cookie，Cookie 也不会写进配置、笔记或日志。
+刷到有用的视频就收藏。需要整理时运行一次同步，新收藏会变成可搜索的本地 Markdown 笔记。
 
 [![CI](https://github.com/tars1230/douyin-favorites-to-knowledge/actions/workflows/ci.yml/badge.svg)](https://github.com/tars1230/douyin-favorites-to-knowledge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 
-本项目只访问你主动登录账号后有权查看的收藏内容，不绕过登录和平台访问控制。
+不用复制 Cookie，不用先选模型，也不用理解内部处理步骤。
 
-## 两种模式
+## 最短使用路径
 
-| 模式 | 适合谁 | 默认行为 |
-|---|---|---|
-| 轻量模式 `light` | 先把收藏稳定沉淀到本地的人 | 登录、扫描、人工批准、写入 Markdown 和 SQLite 账本 |
-| 完整模式 `full` | 已有转录、分析或通知能力的人 | 在轻量流程上，按顺序调用可选的转录、分析和通知 adapter |
-
-轻量模式是默认项，不下载大模型，也不要求 MiniMax。完整模式允许按电脑实际情况选择：
-
-- 转录：本地语音模型或自定义 adapter；
-- 分析：本地模型、MiniMax 或其他 adapter；
-- 通知：飞书或其他 adapter。
-
-`provider` 只是明确记录你选择的能力来源，真正调用由 `module:function` adapter 完成。当前仓库没有内置抖音视频下载器、模型自动安装器、MiniMax 客户端或飞书机器人，因此不会把这些外部能力伪装成开箱即用。这样可以避免绑定某一台电脑、某一个模型和某一种通知服务。
-
-## 工作流程
-
-```text
-官方页面登录 -> 扫描收藏
-                    |
-                    +-> 可选转录 -> 可选分析
-                    |
-                    v
-              review.json
-                    |
-              明确批准内容
-                    |
-                    v
-        Markdown 笔记 + SQLite 幂等账本
-                    |
-                    +-> 可选通知
-```
-
-- `scan` 只生成待审核清单，不改知识库；
-- `review` 重新校验内容哈希，并要求明确批准全部或部分条目；
-- `promote` 校验审核文件未被修改，再原子写入笔记和账本；
-- 同一批内容重复运行不会重复入库，已入库内容发生变化时会停止并要求人工迁移。
-
-## 安装
-
-第一次使用请直接选择轻量模式。确认收藏能正常写入 Markdown 后，再考虑本地转录、MiniMax 或飞书通知。
-
-### 1. 下载项目
-
-安装了 Git 时运行：
+安装：
 
 ```bash
 git clone https://github.com/tars1230/douyin-favorites-to-knowledge.git
 cd douyin-favorites-to-knowledge
-```
-
-没有 Git 也可以在 GitHub 页面点击 **Code -> Download ZIP**，解压后在终端进入该目录。
-
-### 2. 创建 Python 环境
-
-需要 Python 3.10 或更高版本，先确认版本：
-
-```bash
-python3 --version
-```
-
-macOS / Linux：
-
-```bash
 python3 -m venv .venv
 . .venv/bin/activate
 python -m pip install .
 ```
 
-Windows PowerShell：
+第一次使用：
+
+```bash
+douyin-favorites-knowledge setup
+```
+
+按照提示选择知识库目录，随后在打开的抖音官方页面正常登录。
+
+以后同步只需要：
+
+```bash
+douyin-favorites-knowledge sync
+```
+
+命令会列出本次新增收藏。输入 `y` 后才会写入知识库；输入其他内容会取消，不改任何文件。
+
+## 让 AI 帮你安装
+
+把下面这句话发给 Codex、Claude Code 或其他能够操作本机项目的编程 Agent：
+
+```text
+请安装并配置这个项目：https://github.com/tars1230/douyin-favorites-to-knowledge
+把我的抖音收藏同步到本地 Markdown 知识库。先使用默认轻量配置，不要让我复制 Cookie。
+```
+
+Agent 应当完成安装并运行 `setup`。你只需要确认知识库目录，并在抖音官方页面登录。
+
+## 安装说明
+
+### 系统要求
+
+- Python 3.10 或更高版本；
+- Chrome、Edge 或 Playwright Chromium；
+- 有权访问自己账号中的抖音收藏。
+
+先检查 Python：
+
+```bash
+python3 --version
+```
+
+Windows PowerShell 使用下面的环境命令：
 
 ```powershell
 py -3 -m venv .venv
@@ -85,254 +69,172 @@ py -3 -m venv .venv
 python -m pip install .
 ```
 
-安装完成后，这条命令应能显示帮助：
+没有 Git 时，可以在 GitHub 页面点击 **Code -> Download ZIP**，解压后进入项目目录。
 
-```bash
-douyin-favorites-knowledge --help
-```
-
-### 3. 准备浏览器
-
-系统会优先使用 Chrome 或 Edge。两者都没有时，安装一次 Playwright Chromium：
+系统会优先使用 Chrome 或 Edge。两者都没有时运行：
 
 ```bash
 python -m playwright install chromium
 ```
 
-### 4. 可选安装 Codex Skill
+安装成功后，`douyin-favorites-knowledge --help` 会显示中文命令说明。
 
-只使用命令行时可以跳过。需要在 Codex 中调用本项目时再安装：
+### `setup` 做了什么
 
-```bash
-cp -R skill ~/.codex/skills/douyin-favorites-to-knowledge
-```
+`setup` 只做三件事：
 
-## 第一次入库
+1. 询问 Markdown 或 Obsidian 知识库目录；
+2. 在系统应用配置目录生成安全的默认配置；
+3. 打开抖音官方页面完成登录。
 
-### 1. 创建自己的配置
+配置文件不保存 Cookie、API key、密码或 token。Cookie 只留在独立的本地浏览器 profile 中。
 
-不要直接修改示例文件。macOS / Linux：
-
-```bash
-cp config/config.example.json config/config.local.json
-```
-
-Windows PowerShell：
-
-```powershell
-Copy-Item config/config.example.json config/config.local.json
-```
-
-`config/config.local.json` 已加入 `.gitignore`，不会被意外提交。默认配置已经是轻量模式：
-
-```json
-{
-  "schema_version": 2,
-  "mode": "light",
-  "knowledge_dir": "../.runtime/knowledge",
-  "ledger_path": "../.runtime/state/ledger.sqlite3",
-  "transcription": {"enabled": false, "provider": "none"},
-  "analysis": {"enabled": false, "provider": "none"},
-  "notification": {"enabled": false, "provider": "none"}
-}
-```
-
-只需要先修改 `knowledge_dir`：
-
-- 普通 Markdown 知识库：填写你准备存放笔记的目录；
-- Obsidian：填写 Vault 里的一个独立子目录；
-- 相对路径以配置文件所在目录为基准，也可以使用绝对路径；
-- `ledger_path` 是防重复入库的本地账本，通常保持默认即可。
-
-### 2. 检查配置
+常用选项：
 
 ```bash
-douyin-favorites-knowledge --config config/config.local.json check-config
+# 直接指定知识库目录
+douyin-favorites-knowledge setup --knowledge-dir "我的知识库目录"
+
+# 只创建配置，稍后再登录
+douyin-favorites-knowledge setup --knowledge-dir "我的知识库目录" --skip-login
+
+# 重新选择知识库目录
+douyin-favorites-knowledge setup --force --knowledge-dir "新的知识库目录"
 ```
 
-首次使用应看到类似结果：
+### `sync` 做了什么
 
-```json
-{
-  "mode": "light",
-  "schema_version": 2,
-  "stages": {
-    "analysis": {"enabled": false, "provider": "none"},
-    "notification": {"enabled": false, "provider": "none"},
-    "transcription": {"enabled": false, "provider": "none"}
-  },
-  "status": "valid"
-}
+```text
+扫描新增收藏 -> 展示标题 -> 等待确认 -> 写入 Markdown -> 记录防重账本
 ```
 
-这条命令不会输出 Cookie、配置路径、知识库路径或 adapter 名称。注意：`--config` 必须写在 `check-config`、`scan`、`review`、`promote` 等子命令之前。
+- 没有新增时返回 `no_changes`；
+- 有新增时先展示标题，不会直接写入；
+- 确认后返回 `committed`；
+- 同一条收藏再次同步不会重复入库；
+- 登录过期时会重新打开登录页，而不是误报“没有新增”。
 
-### 3. 登录抖音
+只查看新增、不写入：
+
+```bash
+douyin-favorites-knowledge sync --dry-run
+```
+
+用于明确授权的无人值守任务：
+
+```bash
+douyin-favorites-knowledge sync --yes --no-login-prompt
+```
+
+`--yes` 表示批准本次全部新增；`--no-login-prompt` 表示登录过期时直接失败。项目提供同步命令，但不会擅自创建系统定时任务。
+
+## 输出结果
+
+每条批准收藏生成一份独立 Markdown 文件，包含：
+
+- 标题、作者和抖音原始地址；
+- 收藏描述；
+- 已提供或通过扩展生成的转录文本；
+- 标签和采集时间。
+
+`setup` 选择 Obsidian Vault 中的子目录后，笔记可以直接在 Obsidian 中打开，不要求安装 Obsidian 插件。
+
+## 自检与登录管理
+
+检查当前配置，不显示本机路径、Cookie、adapter 或凭据：
+
+```bash
+douyin-favorites-knowledge check-config
+```
+
+管理抖音登录状态：
 
 ```bash
 douyin-favorites-knowledge login
-```
-
-浏览器会打开抖音官方页面。正常登录后，终端返回 `authenticated`。后续运行会复用这个独立本地会话。
-
-### 4. 扫描新增收藏
-
-```bash
-douyin-favorites-knowledge --config config/config.local.json scan \
-  --review .runtime/review.json
-```
-
-返回 `status: written` 表示待审核清单已经生成。`candidate_count` 是本次等待审核的新增数量；为 `0` 时不会生成可批准内容。
-
-### 5. 批准并写入知识库
-
-确认 review 内容后批准全部条目：
-
-```bash
-douyin-favorites-knowledge --config config/config.local.json review \
-  --review .runtime/review.json \
-  --approve-all \
-  --approval .runtime/approval.json
-
-douyin-favorites-knowledge --config config/config.local.json promote \
-  --review .runtime/review.json \
-  --approval .runtime/approval.json
-```
-
-返回 `status: committed` 后，打开 `knowledge_dir`：每条批准收藏应有一份 `.md` 文件。再次运行同一批内容时，`promoted_count` 为 `0`，不会重复入库。
-
-需要只批准部分内容时，不使用 `--approve-all`，改为重复指定 ID：
-
-```bash
-douyin-favorites-knowledge --config config/config.local.json review \
-  --review .runtime/review.json \
-  --approve 7000000000000000001 \
-  --approve 7000000000000000002 \
-  --approval .runtime/approval.json
-```
-
-登录状态管理：
-
-```bash
 douyin-favorites-knowledge status
 douyin-favorites-knowledge logout
 ```
 
-无人值守任务可在 `scan` 后加 `--no-login-prompt`。登录过期时任务会明确失败，不会把“没抓到内容”误判成“没有新增收藏”。
+## 常见问题
 
-## 完整模式配置
+| 现象 | 处理方法 |
+|---|---|
+| 提示尚未完成配置 | 运行 `douyin-favorites-knowledge setup` |
+| 找不到 Chrome、Edge 或 Chromium | 运行 `python -m playwright install chromium` |
+| 返回 `login_required` | 运行 `douyin-favorites-knowledge login` |
+| `candidate_count` 为 `0` | 当前没有未入库的新收藏，不是错误 |
+| `secret-like key blocked` | 从配置删除密钥、Cookie 或 token，改用环境变量或密钥管理器 |
+| 想更换知识库目录 | 运行 `douyin-favorites-knowledge setup --force` |
+| 自动任务等待确认 | 使用显式参数 `sync --yes --no-login-prompt` |
 
-完整模式是进阶功能。启用前先确认：
+仍无法判断时，保留执行命令、`check-config` 输出和脱敏后的 `ERROR:` 文本。不要提交浏览器 profile、Cookie 或密钥文件。
 
-1. 轻量模式已经成功完成一次入库；
-2. 对应 adapter 已安装在当前虚拟环境，能通过 `module:function` 导入；
-3. 本地模型或云端模型名称真实可用；
-4. API key、飞书密钥等已经放进环境变量、系统钥匙串或 Secret Manager。
+## 进阶配置
 
-下面只展示结构。adapter 名称和模型名必须替换成当前电脑上真实可用的实现：
+普通使用到这里已经足够。只有需要本地转录、模型分析或飞书通知时，才继续本节。
 
-```json
-{
-  "schema_version": 2,
-  "mode": "full",
-  "knowledge_dir": "../.runtime/knowledge",
-  "ledger_path": "../.runtime/state/ledger.sqlite3",
-  "transcription": {
-    "enabled": true,
-    "provider": "local",
-    "adapter": "my_pipeline:transcribe",
-    "model": "my-local-asr-model"
-  },
-  "analysis": {
-    "enabled": true,
-    "provider": "minimax",
-    "adapter": "my_pipeline:analyze",
-    "model": "my-minimax-model"
-  },
-  "notification": {
-    "enabled": true,
-    "provider": "feishu",
-    "adapter": "my_pipeline:notify"
-  }
-}
-```
+`setup` 默认配置文件位置：
 
-每个阶段都可以独立关闭或换成 `adapter`。使用本地模型时，`model` 写本机实际模型；使用 MiniMax 时，`model` 写账号可用模型。API key、飞书密钥和其他凭据只允许从环境变量、系统钥匙串或宿主 Secret Manager 读取，配置文件中的 secret、token、password、cookie、credential 和 API key 类字段会被拒绝。
+- macOS：`~/Library/Application Support/douyin-favorites-to-knowledge/config.json`；
+- Windows：`%APPDATA%\douyin-favorites-to-knowledge\config.json`；
+- Linux：`${XDG_CONFIG_HOME:-~/.config}/douyin-favorites-to-knowledge/config.json`。
 
-修改后再次运行 `check-config`。它只验证配置契约；adapter 能否连接模型或飞书，仍要由对应 adapter 自己提供连接测试。
+也可以通过 `DOUYIN_FAVORITES_CONFIG` 指定自定义配置路径。环境变量只保存路径，不要放任何凭据。
 
-## Adapter 契约
+### 可选能力
 
-配置中的转录和分析 adapter 会依次收到单条收藏与当前阶段上下文：
+配置 v2 支持三个独立阶段：
+
+| 阶段 | 可选来源 |
+|---|---|
+| 转录 | 本地语音模型或自定义 adapter |
+| 分析 | 本地模型、MiniMax 或其他 adapter |
+| 通知 | 飞书或其他 adapter |
+
+MiniMax 不是必需项，本地模型也不写死。不同电脑可以选择不同模型。具体能力通过 `module:function` adapter 接入；当前仓库没有内置视频下载器、模型自动安装器、MiniMax 客户端或飞书机器人。
+
+完整配置结构见 [config/config.schema.json](config/config.schema.json)。修改前先完成一次默认 `setup -> sync`，并确认 adapter 能在当前虚拟环境中导入。所有凭据只能来自环境变量、系统钥匙串或 Secret Manager。
+
+Adapter 契约：
 
 ```python
 def transcribe(item: dict, context: dict) -> dict:
-    # context: mode、stage、provider、model、options
     return {"transcript": "..."}
 
 def analyze(item: dict, context: dict) -> dict:
     return {"tags": ["主题"], "description": "..."}
 
 def notify(event: dict, context: dict) -> None:
-    # 仅在本地事务提交成功后调用
     ...
 ```
 
-Adapter 不得修改 `aweme_id`，传入的 `source_url` 也不会覆盖系统生成的规范地址。如果转录需要下载视频，adapter 必须使用已授权会话、限制临时文件范围并在完成后清理；核心仓库目前不负责下载视频。
+如果转录需要下载视频，adapter 必须使用已授权会话、限制临时文件范围并完成清理。核心仓库不负责下载视频。
 
-原有命令行扩展仍然可用：
+### 原子命令
 
-```bash
-douyin-favorites-knowledge --config config.json scan \
-  --enricher my_module:enrich \
-  --review review.json
+`sync` 内部复用以下安全事务。需要局部批准、JSON 导入或调试 adapter 时，可以单独调用：
 
-douyin-favorites-knowledge --config config.json promote \
-  --review review.json \
-  --approval approval.json \
-  --notifier my_module:notify
+```text
+scan -> review -> promote
 ```
 
-命令行 `--notifier` 会覆盖配置中的通知 adapter。
+```bash
+douyin-favorites-knowledge --config config.json scan --review review.json
+douyin-favorites-knowledge --config config.json review \
+  --review review.json --approve-all --approval approval.json
+douyin-favorites-knowledge --config config.json promote \
+  --review review.json --approval approval.json
+```
 
-## 输入与 Obsidian
+每一步都支持 `--dry-run`。批准文件绑定 review 的 SHA-256，入库使用 SQLite 账本和原子文件替换。
 
-浏览器收藏、授权导出的 JSON 和自定义 collector 最终都会归一成同一结构。至少需要：
+## 安全边界
 
-| 字段 | 必需 | 说明 |
-|---|---|---|
-| `aweme_id` | 是 | 6 到 30 位数字，作为不可变 ID |
-| `title` 或 `description` | 是 | 至少一个非空 |
-| `author` | 否 | 作者公开信息 |
-| `transcript` | 否 | 转录文本，通过安全检查后写入笔记 |
-| `tags` | 否 | 去重并排序的标签 |
-| `observed_at` | 否 | 采集时间 |
-
-输出是普通 Markdown 文件，因此 `knowledge_dir` 可以直接指向 Obsidian Vault 中的一个独立目录。项目不修改 Obsidian 设置，也不要求安装 Obsidian 插件。
-
-## 常见问题
-
-| 现象 | 怎么处理 |
-|---|---|
-| `--config is required` | 把 `--config config/config.local.json` 放在子命令前面 |
-| `config ... must` 或 `unknown config fields` | 先对照示例恢复字段，再运行 `check-config` |
-| `secret-like key blocked` | 从 JSON 删除密钥、Cookie 或 token，改从环境变量或密钥管理器读取 |
-| 找不到 Chrome、Edge 或 Chromium | 运行 `python -m playwright install chromium` |
-| 返回 `login_required` | 运行 `douyin-favorites-knowledge login` 重新登录 |
-| `candidate_count` 为 `0` | 当前没有未入库的新收藏；这不是错误 |
-| 完整模式提示缺少 `adapter` 或 `model` | 暂时切回 `light`，或先安装并验证对应 adapter 和模型 |
-| adapter 连接 MiniMax、飞书或本地模型失败 | 检查该 adapter 的环境变量、模型名称和连接测试；核心不会读取其凭据 |
-
-仍无法判断时，依次保留 `check-config` 输出、执行命令和脱敏后的 `ERROR:` 文本。不要提交浏览器 profile、Cookie 或配置外的密钥文件。
-
-## 隐私与安全边界
-
-- 登录发生在 CLI 打开的抖音官方页面中；
-- 浏览器状态保存在系统应用数据目录下的独立 profile；
-- Cookie 不会作为命令行参数或配置字段，也不会进入 review、笔记和日志；
-- `logout` 会清除保存的浏览器会话；卸载 Python 包不会擅自删除知识库和账本；
+- 只访问用户主动登录账号后有权查看的收藏；
+- 不绕过登录或平台访问控制；
+- Cookie 不作为参数或配置字段，也不进入笔记和日志；
 - 推理标签、NUL、常见密钥格式、可疑配置字段、重复 ID、哈希篡改和冲突文件都会阻止入库；
-- 文本扫描无法识别截图或视频画面中的秘密，本核心只写文本笔记。
+- 文本检查无法识别截图或视频画面中的秘密，本核心只写文本笔记。
 
 ## 验证
 
@@ -341,7 +243,7 @@ python3 -m compileall -q src tests
 PYTHONPATH=src python3 -m unittest discover -s tests -v
 ```
 
-CI 还会把构建后的包安装到全新虚拟环境，并执行一次完整的 fixture 事务。
+CI 会在 Python 3.10 和 3.12 中运行测试，并把构建后的 wheel 安装到全新虚拟环境完成 onboarding 与 fixture E2E。
 
 ## 卸载
 
@@ -350,7 +252,7 @@ douyin-favorites-knowledge logout
 python -m pip uninstall douyin-favorites-to-knowledge
 ```
 
-知识库、SQLite 账本和浏览器 profile 都属于用户数据，不会随包卸载自动删除。
+卸载 Python 包不会自动删除知识库、SQLite 账本或浏览器 profile。
 
 ## 许可证
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,52 @@
-# Douyin Favorites to Knowledge
+# 抖音收藏转本地知识库
 
-Turn your authorized Douyin favorites into reviewed local Markdown notes. The built-in browser collector handles first-run login without asking you to copy or configure cookies.
+把自己账号里新增的抖音收藏，整理成经过审核、可重复运行的本地 Markdown 知识笔记。首次使用会打开抖音官方页面登录，之后复用独立的本地浏览器会话；不用复制 Cookie，Cookie 也不会写进配置、笔记或日志。
 
 [![CI](https://github.com/tars1230/douyin-favorites-to-knowledge/actions/workflows/ci.yml/badge.svg)](https://github.com/tars1230/douyin-favorites-to-knowledge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 
-This project accesses only the favorites of the account that you explicitly sign into. It does not bypass login or platform access controls.
+本项目只访问你主动登录账号后有权查看的收藏内容，不绕过登录和平台访问控制。
 
-## Design
+## 两种模式
+
+| 模式 | 适合谁 | 默认行为 |
+|---|---|---|
+| 轻量模式 `light` | 先把收藏稳定沉淀到本地的人 | 登录、扫描、人工批准、写入 Markdown 和 SQLite 账本 |
+| 完整模式 `full` | 已有转录、分析或通知能力的人 | 在轻量流程上，按顺序调用可选的转录、分析和通知 adapter |
+
+轻量模式是默认项，不下载大模型，也不要求 MiniMax。完整模式允许按电脑实际情况选择：
+
+- 转录：本地语音模型或自定义 adapter；
+- 分析：本地模型、MiniMax 或其他 adapter；
+- 通知：飞书或其他 adapter。
+
+`provider` 只是明确记录你选择的能力来源，真正调用由 `module:function` adapter 完成。当前仓库没有内置抖音视频下载器、模型自动安装器、MiniMax 客户端或飞书机器人，因此不会把这些外部能力伪装成开箱即用。这样可以避免绑定某一台电脑、某一个模型和某一种通知服务。
+
+## 工作流程
 
 ```text
-authorized browser session, export, or adapter
-              |
-              v
-        scan -> review.json
+官方页面登录 -> 扫描收藏
+                    |
+                    +-> 可选转录 -> 可选分析
                     |
                     v
-        review -> approval.json
+              review.json
+                    |
+              明确批准内容
                     |
                     v
-        promote -> Markdown notes + SQLite ledger
+        Markdown 笔记 + SQLite 幂等账本
+                    |
+                    +-> 可选通知
 ```
 
-- `scan` normalizes source items, derives canonical Douyin URLs, blocks leakage, compares the immutable ledger, and writes no knowledge notes.
-- `review` revalidates every content hash and generated note, then requires explicit full or partial approval.
-- `promote` verifies the exact review SHA-256, stages approved notes, atomically replaces each file, and commits idempotency records.
+- `scan` 只生成待审核清单，不改知识库；
+- `review` 重新校验内容哈希，并要求明确批准全部或部分条目；
+- `promote` 校验审核文件未被修改，再原子写入笔记和账本；
+- 同一批内容重复运行不会重复入库，已入库内容发生变化时会停止并要求人工迁移。
 
-## Install
+## 安装
 
 ```bash
 python3 -m venv .venv
@@ -35,21 +54,35 @@ python3 -m venv .venv
 python -m pip install .
 ```
 
-Chrome or Edge is used when available. If neither is installed, install Playwright Chromium once:
+系统会优先使用 Chrome 或 Edge。两者都没有时，安装一次 Playwright Chromium：
 
 ```bash
 python -m playwright install chromium
 ```
 
-Install the Agent Skill separately when needed:
+需要在 Codex 中调用 Skill 时，再安装 Skill 目录：
 
 ```bash
 cp -R skill ~/.codex/skills/douyin-favorites-to-knowledge
 ```
 
-## First sync
+## 轻量模式快速开始
 
-Create a config from [config/config.example.json](config/config.example.json), then run `scan`. On the first run, a local browser opens for normal Douyin login. Later runs reuse that app-owned browser session.
+复制 [config/config.example.json](config/config.example.json) 后修改知识库位置。默认配置已经是轻量模式：
+
+```json
+{
+  "schema_version": 2,
+  "mode": "light",
+  "knowledge_dir": "../.runtime/knowledge",
+  "ledger_path": "../.runtime/state/ledger.sqlite3",
+  "transcription": {"enabled": false, "provider": "none"},
+  "analysis": {"enabled": false, "provider": "none"},
+  "notification": {"enabled": false, "provider": "none"}
+}
+```
+
+第一次扫描会打开浏览器，正常登录抖音即可：
 
 ```bash
 douyin-favorites-knowledge --config config/config.example.json scan \
@@ -65,7 +98,7 @@ douyin-favorites-knowledge --config config/config.example.json promote \
   --approval .runtime/approval.json
 ```
 
-The login can also be managed explicitly:
+也可以单独管理登录状态：
 
 ```bash
 douyin-favorites-knowledge login
@@ -73,122 +106,116 @@ douyin-favorites-knowledge status
 douyin-favorites-knowledge logout
 ```
 
-`login`, `status`, and `logout` never print cookie values or require a config file. For unattended jobs, add `--no-login-prompt` to `scan` so an expired session fails instead of opening a browser.
+无人值守任务可在 `scan` 后加 `--no-login-prompt`。登录过期时任务会明确失败，不会把“没抓到内容”误判成“没有新增收藏”。
 
-## Quick fixture E2E
+## 完整模式配置
 
-Keep runtime state outside the repository when using real data. The included example deliberately writes to ignored `.runtime/` paths.
+下面只展示结构。adapter 名称和模型名要替换成你电脑上实际可用的实现：
 
-```bash
-douyin-favorites-knowledge --config config/config.example.json scan \
-  --input tests/fixtures/favorites.json \
-  --source-label synthetic_fixture \
-  --review .runtime/review.json
-
-douyin-favorites-knowledge --config config/config.example.json review \
-  --review .runtime/review.json \
-  --approve-all \
-  --approval .runtime/approval.json
-
-douyin-favorites-knowledge --config config/config.example.json promote \
-  --review .runtime/review.json \
-  --approval .runtime/approval.json \
-  --dry-run
-
-douyin-favorites-knowledge --config config/config.example.json promote \
-  --review .runtime/review.json \
-  --approval .runtime/approval.json
+```json
+{
+  "schema_version": 2,
+  "mode": "full",
+  "knowledge_dir": "../.runtime/knowledge",
+  "ledger_path": "../.runtime/state/ledger.sqlite3",
+  "transcription": {
+    "enabled": true,
+    "provider": "local",
+    "adapter": "my_pipeline:transcribe",
+    "model": "my-local-asr-model"
+  },
+  "analysis": {
+    "enabled": true,
+    "provider": "minimax",
+    "adapter": "my_pipeline:analyze",
+    "model": "my-minimax-model"
+  },
+  "notification": {
+    "enabled": true,
+    "provider": "feishu",
+    "adapter": "my_pipeline:notify"
+  }
+}
 ```
 
-Run the last command again: it succeeds with `promoted_count: 0` and `skipped_count: 2`.
+每个阶段都可以独立关闭或换成 `adapter`。使用本地模型时，`model` 写本机实际模型；使用 MiniMax 时，`model` 写账号可用模型。API key、飞书密钥和其他凭据只允许从环境变量、系统钥匙串或宿主 Secret Manager 读取，配置文件中的 secret、token、password、cookie、credential 和 API key 类字段会被拒绝。
 
-## Input schema
+## Adapter 契约
 
-The input is a JSON list, or an object with an `items` list. Each item accepts:
-
-| Field | Required | Behavior |
-|---|---|---|
-| `aweme_id` | yes | 6-30 digits; becomes the immutable identity |
-| `title` or `description` | yes | At least one must be non-empty |
-| `author` | no | Stored as public source metadata |
-| `description` | no | Included in the note |
-| `transcript` | no | Included only after leakage checks |
-| `tags` | no | Non-empty strings, deduplicated and sorted |
-| `observed_at` | no | Caller-supplied provenance timestamp |
-| `source_url` | ignored | Replaced with `https://www.douyin.com/video/<aweme_id>` |
-
-Unknown source fields are not copied into notes. Query parameters, cookies, and collector-specific metadata therefore do not leak through by default.
-
-## Browser privacy
-
-- Login happens on Douyin's website in a dedicated local browser profile.
-- Raw cookies are not accepted as CLI arguments or config fields and are never written to review files or notes.
-- The default profile is stored under the operating system's application-state directory, outside the repository.
-- `logout` clears the saved browser session. Uninstalling the Python package does not silently delete user data.
-- Douyin can expire a session or change its private web response shape. The collector fails closed and asks for login or an update instead of treating that failure as an empty collection.
-
-Use `DOUYIN_FAVORITES_PROFILE_DIR` only when you need to relocate the app-owned profile. Do not point it at a daily browser profile or a broad directory.
-
-## Adapters
-
-Use `module:function` specs:
+配置中的转录和分析 adapter 会依次收到单条收藏与当前阶段上下文：
 
 ```python
-def collector(config: dict) -> list[dict]:
-    ...
+def transcribe(item: dict, context: dict) -> dict:
+    # context: mode、stage、provider、model、options
+    return {"transcript": "..."}
 
-def enricher(item: dict, config: dict) -> dict:
-    ...
+def analyze(item: dict, context: dict) -> dict:
+    return {"tags": ["主题"], "description": "..."}
 
-def notifier(event: dict, config: dict) -> None:
+def notify(event: dict, context: dict) -> None:
+    # 仅在本地事务提交成功后调用
     ...
 ```
 
-The config accepts output paths only and rejects secret-like keys. Adapters must read credentials from their host environment or secret manager. The notifier runs after commit, so a notifier error means local promotion may already be complete.
+Adapter 不得修改 `aweme_id`，传入的 `source_url` 也不会覆盖系统生成的规范地址。如果转录需要下载视频，adapter 必须使用已授权会话、限制临时文件范围并在完成后清理；核心仓库目前不负责下载视频。
 
-## Safety gates
+原有命令行扩展仍然可用：
 
-The pipeline blocks before promotion on:
+```bash
+douyin-favorites-knowledge --config config.json scan \
+  --enricher my_module:enrich \
+  --review review.json
 
-- `<think>` / `<analysis>` reasoning tags;
-- Unicode replacement characters and NUL bytes;
-- common live-secret token shapes;
-- secret-like config keys;
-- invalid or conflicting duplicate IDs;
-- modified notes or content hashes;
-- a review changed after approval;
-- changed content for an already promoted ID;
-- conflicting untracked note files.
+douyin-favorites-knowledge --config config.json promote \
+  --review review.json \
+  --approval approval.json \
+  --notifier my_module:notify
+```
 
-Text scanning cannot detect secrets rendered inside screenshots or video. This core intentionally writes text notes only.
+命令行 `--notifier` 会覆盖配置中的通知 adapter。
 
-## Dry-run and recovery
+## 输入与 Obsidian
 
-Every command supports `--dry-run` and avoids writes for that stage.
+浏览器收藏、授权导出的 JSON 和自定义 collector 最终都会归一成同一结构。至少需要：
 
-- If scan fails, fix the source or adapter and rerun; notes and ledger were untouched.
-- If review fails, discard the approval candidate and fix the manifest source.
-- If promote is interrupted after a note replacement but before ledger commit, rerun the same review and approval. Identical orphan notes are accepted; conflicting notes are blocked.
-- Do not edit a promoted item in place. Use a separately reviewed migration process for changed content.
+| 字段 | 必需 | 说明 |
+|---|---|---|
+| `aweme_id` | 是 | 6 到 30 位数字，作为不可变 ID |
+| `title` 或 `description` | 是 | 至少一个非空 |
+| `author` | 否 | 作者公开信息 |
+| `transcript` | 否 | 转录文本，通过安全检查后写入笔记 |
+| `tags` | 否 | 去重并排序的标签 |
+| `observed_at` | 否 | 采集时间 |
 
-## Test
+输出是普通 Markdown 文件，因此 `knowledge_dir` 可以直接指向 Obsidian Vault 中的一个独立目录。项目不修改 Obsidian 设置，也不要求安装 Obsidian 插件。
+
+## 隐私与安全边界
+
+- 登录发生在 CLI 打开的抖音官方页面中；
+- 浏览器状态保存在系统应用数据目录下的独立 profile；
+- Cookie 不会作为命令行参数或配置字段，也不会进入 review、笔记和日志；
+- `logout` 会清除保存的浏览器会话；卸载 Python 包不会擅自删除知识库和账本；
+- 推理标签、NUL、常见密钥格式、可疑配置字段、重复 ID、哈希篡改和冲突文件都会阻止入库；
+- 文本扫描无法识别截图或视频画面中的秘密，本核心只写文本笔记。
+
+## 验证
 
 ```bash
 python3 -m compileall -q src tests
 PYTHONPATH=src python3 -m unittest discover -s tests -v
 ```
 
-CI also installs the built wheel into a fresh virtual environment and runs the fixture transaction through the console command.
+CI 还会把构建后的包安装到全新虚拟环境，并执行一次完整的 fixture 事务。
 
-## Uninstall
+## 卸载
 
 ```bash
 douyin-favorites-knowledge logout
 python -m pip uninstall douyin-favorites-to-knowledge
 ```
 
-Uninstalling the package intentionally does not delete your configured knowledge directory, SQLite ledger, or browser profile. Remove those data paths only after backing them up and verifying the exact target.
+知识库、SQLite 账本和浏览器 profile 都属于用户数据，不会随包卸载自动删除。
 
-## License
+## 许可证
 
 [MIT](LICENSE)

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -1,5 +1,18 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
+  "mode": "light",
   "knowledge_dir": "../.runtime/knowledge",
-  "ledger_path": "../.runtime/state/ledger.sqlite3"
+  "ledger_path": "../.runtime/state/ledger.sqlite3",
+  "transcription": {
+    "enabled": false,
+    "provider": "none"
+  },
+  "analysis": {
+    "enabled": false,
+    "provider": "none"
+  },
+  "notification": {
+    "enabled": false,
+    "provider": "none"
+  }
 }

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1,12 +1,130 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "douyin-favorites-to-knowledge config",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["schema_version", "knowledge_dir", "ledger_path"],
-  "properties": {
-    "schema_version": {"const": 1},
-    "knowledge_dir": {"type": "string", "minLength": 1},
-    "ledger_path": {"type": "string", "minLength": 1}
-  }
+  "$defs": {
+    "base": {
+      "type": "object",
+      "required": ["schema_version", "knowledge_dir", "ledger_path"],
+      "properties": {
+        "knowledge_dir": {"type": "string", "minLength": 1},
+        "ledger_path": {"type": "string", "minLength": 1}
+      }
+    },
+    "disabledStage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "provider"],
+      "properties": {
+        "enabled": {"const": false},
+        "provider": {"const": "none"}
+      }
+    },
+    "transcriptionStage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "provider", "adapter"],
+      "properties": {
+        "enabled": {"const": true},
+        "provider": {"enum": ["local", "adapter"]},
+        "adapter": {"type": "string", "pattern": "^[^:]+:[^:]+$"},
+        "model": {"type": "string"},
+        "options": {"type": "object"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"provider": {"const": "local"}}},
+          "then": {"required": ["model"], "properties": {"model": {"minLength": 1}}}
+        }
+      ]
+    },
+    "analysisStage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "provider", "adapter"],
+      "properties": {
+        "enabled": {"const": true},
+        "provider": {"enum": ["local", "minimax", "adapter"]},
+        "adapter": {"type": "string", "pattern": "^[^:]+:[^:]+$"},
+        "model": {"type": "string"},
+        "options": {"type": "object"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"provider": {"enum": ["local", "minimax"]}}},
+          "then": {"required": ["model"], "properties": {"model": {"minLength": 1}}}
+        }
+      ]
+    },
+    "notificationStage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "provider", "adapter"],
+      "properties": {
+        "enabled": {"const": true},
+        "provider": {"enum": ["feishu", "adapter"]},
+        "adapter": {"type": "string", "pattern": "^[^:]+:[^:]+$"},
+        "model": {"type": "string"},
+        "options": {"type": "object"}
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "allOf": [
+        {"$ref": "#/$defs/base"},
+        {
+          "additionalProperties": false,
+          "properties": {
+            "schema_version": {"const": 1},
+            "knowledge_dir": {"type": "string", "minLength": 1},
+            "ledger_path": {"type": "string", "minLength": 1}
+          }
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {"$ref": "#/$defs/base"},
+        {
+          "additionalProperties": false,
+          "properties": {
+            "schema_version": {"const": 2},
+            "mode": {"enum": ["light", "full"]},
+            "knowledge_dir": {"type": "string", "minLength": 1},
+            "ledger_path": {"type": "string", "minLength": 1},
+            "transcription": {
+              "oneOf": [
+                {"$ref": "#/$defs/disabledStage"},
+                {"$ref": "#/$defs/transcriptionStage"}
+              ]
+            },
+            "analysis": {
+              "oneOf": [
+                {"$ref": "#/$defs/disabledStage"},
+                {"$ref": "#/$defs/analysisStage"}
+              ]
+            },
+            "notification": {
+              "oneOf": [
+                {"$ref": "#/$defs/disabledStage"},
+                {"$ref": "#/$defs/notificationStage"}
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "if": {"properties": {"mode": {"const": "light"}}},
+              "then": {
+                "properties": {
+                  "transcription": {"$ref": "#/$defs/disabledStage"},
+                  "analysis": {"$ref": "#/$defs/disabledStage"},
+                  "notification": {"$ref": "#/$defs/disabledStage"}
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "douyin-favorites-to-knowledge"
-version = "1.1.0"
-description = "Authorized browser collection and transactional promotion of Douyin favorites into local knowledge notes"
+version = "1.2.0"
+description = "Authorized Douyin favorites collection with optional transcription and analysis adapters"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,37 +1,43 @@
 ---
 name: douyin-favorites-to-knowledge
-description: Collect an authorized user's Douyin favorites through a locally managed browser login, then review and idempotently promote them into Markdown knowledge notes. Use for first-time login, incremental favorites sync, JSON import, review, or local knowledge-base promotion; do not use to bypass login, access another account, or publish private data.
+description: 将用户已授权账号中的抖音收藏，通过本地浏览器登录、增量扫描、人工审核和幂等事务写入 Markdown 知识库；按需接入本地转录、MiniMax 或其他分析模型及飞书通知。用于首次登录、收藏同步、JSON 导入、审核批准、Obsidian 入库或配置可选 adapter；不得绕过登录、访问他人账号或泄露私密数据。
 ---
 
-# Douyin Favorites to Knowledge
+# 抖音收藏转本地知识库
 
-Use the packaged CLI. Prefer its built-in browser collector; use JSON or custom adapters only when the user already has an authorized export or integration. Never ask the user to paste cookies.
+使用仓库提供的 CLI。默认选择轻量模式；只有用户已经具备可靠的转录、模型或通知 adapter 时，才启用完整模式。不要要求用户复制 Cookie。
 
-## Preconditions
+## 先确定模式
 
-- The user is authorized to access the source favorites.
-- The collector complies with the platform terms and local law.
-- Browser state stays in the app-owned local profile; never print or export it.
-- Adapter credentials stay in the host environment or secret store.
-- The JSON config contains only output paths; secret-like keys are rejected.
+- `light`：官方页面登录、扫描、审核、批准、写入 Markdown 与 SQLite 账本。
+- `full`：在轻量流程中依次增加可选转录、分析和通知 adapter。
 
-## Transaction
+MiniMax 不是必需项。本地模型名称因电脑而异，必须以用户实际可用模型为准。`provider` 记录选择，`adapter` 执行调用；不要声称仓库会自动下载视频、安装模型或配置飞书。
 
-### 1. Scan
+## 前置边界
 
-Create a candidate review manifest without changing notes or the ledger. With no source flag, `scan` uses the built-in browser collector. The first run opens Douyin for normal login and later runs reuse that local session:
+- 用户有权访问来源收藏，采集方式符合平台条款和当地法律。
+- 浏览器状态只留在应用独立 profile，不打印、不导出。
+- Cookie、API key、飞书密钥等凭据只从环境变量、系统钥匙串或 Secret Manager 读取。
+- JSON 配置只保存路径、provider、模型名和非敏感选项；可疑密钥字段会被拒绝。
+
+## 事务流程
+
+### 1. 扫描
+
+无来源参数时使用内置浏览器 collector。首次运行打开抖音官方页面登录，之后复用本地会话：
 
 ```bash
 douyin-favorites-knowledge --config config.json scan --review review.json
 ```
 
-For unattended runs, add `--no-login-prompt` so an expired login fails closed. Use `douyin-favorites-knowledge login`, `status`, or `logout` to manage the app-owned session explicitly. These commands do not need `--config`.
+无人值守任务加 `--no-login-prompt`，让登录过期明确失败。可用 `login`、`status`、`logout` 单独管理会话，这三个命令不需要配置文件。
 
-For an authorized export, add `--input favorites.json`. For a custom integration, add `--collector module:function`. The collector receives the non-secret config object and returns iterable item objects. Add `--enricher module:function` only when enrichment is independently authorized.
+授权导出使用 `--input favorites.json`；外部 collector 使用 `--collector module:function`。配置为完整模式时，CLI 会按 `transcription -> analysis` 顺序调用已启用的 adapter。临时的一次性增强仍可用 `--enricher module:function`。
 
-### 2. Review
+### 2. 审核与批准
 
-Validate hashes, schema, canonical source URLs, generated notes, duplicate IDs, and reasoning/secret leakage. Approval must be explicit:
+先校验内容哈希、规范来源地址、笔记内容、重复 ID 和敏感信息，再明确批准：
 
 ```bash
 douyin-favorites-knowledge --config config.json review \
@@ -40,9 +46,9 @@ douyin-favorites-knowledge --config config.json review \
   --approval approval.json
 ```
 
-Use repeated `--approve <aweme_id>` for partial approval. Do not edit the review after approval; promotion verifies its SHA-256.
+部分批准时重复使用 `--approve <aweme_id>`。批准后不要修改 review，promote 会校验其 SHA-256。
 
-### 3. Promote
+### 3. 写入知识库
 
 ```bash
 douyin-favorites-knowledge --config config.json promote \
@@ -50,48 +56,37 @@ douyin-favorites-knowledge --config config.json promote \
   --approval approval.json
 ```
 
-Promotion stages Markdown notes, atomically replaces final files, then commits immutable content hashes to SQLite. Repeating the same promotion is a no-op. Changed content for an already promoted ID is blocked for manual migration.
+CLI 先原子写入 Markdown，再提交不可变内容哈希到 SQLite。同一内容重复执行是空操作。已入库 ID 的内容发生变化时停止，交由人工迁移。配置通知 adapter 后，仅在本地提交成功且确有新增时调用。
 
-## Dry-run
-
-All three commands accept `--dry-run`. Dry-run performs validation and reports counts but does not write its stage artifact or mutate notes/ledger.
-
-## Blocking behavior
-
-Stop on:
-
-- `<think>` or `<analysis>` reasoning tags;
-- Unicode replacement characters, NUL bytes, or common live-secret patterns;
-- secret-like config keys;
-- malformed or duplicate IDs;
-- note/content hash mismatch;
-- approval hash mismatch;
-- changed content for an immutable promoted ID;
-- an untracked note file with conflicting content.
-
-Never convert these failures into warnings to keep automation moving.
-
-## Adapter contracts
+## Adapter 规则
 
 ```python
-def collector(config: dict) -> list[dict]: ...
-def enricher(item: dict, config: dict) -> dict: ...
-def notifier(event: dict, config: dict) -> None: ...
+def transcribe(item: dict, context: dict) -> dict: ...
+def analyze(item: dict, context: dict) -> dict: ...
+def notify(event: dict, context: dict) -> None: ...
 ```
 
-The notifier runs after the local transaction commits. A notification failure does not mean the notes were rolled back; inspect the command error, then notify again without re-promoting changed data.
+配置阶段的 `context` 只包含 `mode`、`stage`、`provider`、`model` 和 `options`。转录或分析返回字段更新；禁止改变 `aweme_id`。通知发生在本地事务提交之后，通知失败不代表本地笔记已回滚。
 
-## Browser boundary
+如果转录需要下载视频，adapter 必须只使用已授权会话、限制临时目录并主动清理。不要把核心仓库描述成内置下载器。
 
-- Allow login only on the official Douyin page opened by the CLI.
-- Do not request, display, log, or store raw cookies outside the browser profile.
-- Treat `login_required`, response-shape changes, and stalled pagination as blocking failures, not empty success.
-- Do not point `DOUYIN_FAVORITES_PROFILE_DIR` at a daily browser profile or broad directory.
+## 必须阻止
 
-## Verification
+- `<think>` 或 `<analysis>` 推理标签；
+- Unicode 替换字符、NUL 或常见真实密钥格式；
+- secret、token、password、cookie、credential、API key 类配置字段；
+- 非法或冲突的重复 ID；
+- 笔记、内容哈希或批准文件被修改；
+- 已入库 ID 的内容变化；
+- 未登记但同名且内容冲突的笔记。
+
+不要为了自动化继续运行而把这些错误降级为警告。
+
+## 验证
 
 ```bash
-python3 -m unittest discover -s tests -v
+python3 -m compileall -q src tests
+PYTHONPATH=src python3 -m unittest discover -s tests -v
 ```
 
-Fixture success proves the transaction and browser orchestration contracts. Live collection still depends on an authorized Douyin session and the platform's current web behavior.
+fixture 成功只证明事务和浏览器编排契约；真实采集仍依赖有效的授权登录和抖音当前页面结构。

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,94 +1,75 @@
 ---
 name: douyin-favorites-to-knowledge
-description: 将用户已授权账号中的抖音收藏，通过本地浏览器登录、增量扫描、人工审核和幂等事务写入 Markdown 知识库；按需接入本地转录、MiniMax 或其他分析模型及飞书通知。用于首次登录、收藏同步、JSON 导入、审核批准、Obsidian 入库或配置可选 adapter；不得绕过登录、访问他人账号或泄露私密数据。
+description: 将用户已授权账号中的抖音收藏配置并同步到本地 Markdown 或 Obsidian 知识库；提供首次 setup、增量 sync、登录恢复、JSON 导入、局部审核，以及按需接入本地转录、MiniMax 或其他分析模型和飞书通知。不得绕过登录、访问他人账号或泄露 Cookie 与私密数据。
 ---
 
 # 抖音收藏转本地知识库
 
-使用仓库提供的 CLI。默认选择轻量模式；只有用户已经具备可靠的转录、模型或通知 adapter 时，才启用完整模式。不要要求用户复制 Cookie。
+优先使用单入口流程。不要先向用户解释 schema、模式、provider 或 adapter。
 
-## 先确定模式
+## 首次使用
 
-- `light`：官方页面登录、扫描、审核、批准、写入 Markdown 与 SQLite 账本。
-- `full`：在轻量流程中依次增加可选转录、分析和通知 adapter。
-
-MiniMax 不是必需项。本地模型名称因电脑而异，必须以用户实际可用模型为准。`provider` 记录选择，`adapter` 执行调用；不要声称仓库会自动下载视频、安装模型或配置飞书。
-
-首次安装时引导用户复制 `config/config.example.json` 为 `config/config.local.json`，只修改知识库路径，然后先运行：
+确认仓库已经安装后运行：
 
 ```bash
-douyin-favorites-knowledge --config config/config.local.json check-config
+douyin-favorites-knowledge setup
 ```
 
-只有输出 `status: valid` 且 `mode: light` 后，才继续登录和首次扫描。提醒用户 `--config` 必须放在子命令前。完整模式应在轻量模式成功入库后再配置。
+让用户选择 Markdown 或 Obsidian 知识库目录。`setup` 生成默认轻量配置并打开抖音官方页面登录。不要要求用户复制 Cookie。
 
-## 前置边界
-
-- 用户有权访问来源收藏，采集方式符合平台条款和当地法律。
-- 浏览器状态只留在应用独立 profile，不打印、不导出。
-- Cookie、API key、飞书密钥等凭据只从环境变量、系统钥匙串或 Secret Manager 读取。
-- JSON 配置只保存路径、provider、模型名和非敏感选项；可疑密钥字段会被拒绝。
-
-## 事务流程
-
-### 1. 扫描
-
-无来源参数时使用内置浏览器 collector。首次运行打开抖音官方页面登录，之后复用本地会话：
+如果 Agent 在非交互环境执行，明确指定目录：
 
 ```bash
-douyin-favorites-knowledge --config config.json scan --review review.json
+douyin-favorites-knowledge setup --knowledge-dir "用户确认的目录" --skip-login
 ```
 
-无人值守任务加 `--no-login-prompt`，让登录过期明确失败。可用 `login`、`status`、`logout` 单独管理会话，这三个命令不需要配置文件。
+随后让用户在自己的终端运行 `douyin-favorites-knowledge login` 完成网页登录。不要替用户猜测知识库目录。
 
-授权导出使用 `--input favorites.json`；外部 collector 使用 `--collector module:function`。配置为完整模式时，CLI 会按 `transcription -> analysis` 顺序调用已启用的 adapter。临时的一次性增强仍可用 `--enricher module:function`。
-
-### 2. 审核与批准
-
-先校验内容哈希、规范来源地址、笔记内容、重复 ID 和敏感信息，再明确批准：
+## 日常同步
 
 ```bash
-douyin-favorites-knowledge --config config.json review \
-  --review review.json \
-  --approve-all \
-  --approval approval.json
+douyin-favorites-knowledge sync
 ```
 
-部分批准时重复使用 `--approve <aweme_id>`。批准后不要修改 review，promote 会校验其 SHA-256。
+`sync` 展示新增收藏并等待用户确认，然后完成审核、批准和原子入库。用户取消时不写知识库或账本。
 
-### 3. 写入知识库
+只有用户明确要求无人值守自动同步时，才使用：
 
 ```bash
-douyin-favorites-knowledge --config config.json promote \
-  --review review.json \
-  --approval approval.json
+douyin-favorites-knowledge sync --yes --no-login-prompt
 ```
 
-CLI 先原子写入 Markdown，再提交不可变内容哈希到 SQLite。同一内容重复执行是空操作。已入库 ID 的内容发生变化时停止，交由人工迁移。配置通知 adapter 后，仅在本地提交成功且确有新增时调用。
+`--yes` 是批准全部新增的显式授权。不要私自创建 cron 或系统定时任务。
 
-## Adapter 规则
+## 故障处理
 
-```python
-def transcribe(item: dict, context: dict) -> dict: ...
-def analyze(item: dict, context: dict) -> dict: ...
-def notify(event: dict, context: dict) -> None: ...
+先运行：
+
+```bash
+douyin-favorites-knowledge check-config
+douyin-favorites-knowledge status
 ```
 
-配置阶段的 `context` 只包含 `mode`、`stage`、`provider`、`model` 和 `options`。转录或分析返回字段更新；禁止改变 `aweme_id`。通知发生在本地事务提交之后，通知失败不代表本地笔记已回滚。
+- 未配置：运行 `setup`；
+- 登录过期：运行 `login`；
+- 无浏览器：安装 Playwright Chromium；
+- 无新增：把 `no_changes` 当作正常结果；
+- 想换目录：让用户确认后运行 `setup --force --knowledge-dir "新目录"`；
+- secret-like 配置错误：删除配置中的凭据，改从环境或 Secret Manager 读取。
 
-如果转录需要下载视频，adapter 必须只使用已授权会话、限制临时目录并主动清理。不要把核心仓库描述成内置下载器。
+`check-config` 不输出本机路径、adapter 或凭据。不要请求或显示浏览器 profile 和 Cookie。
 
-## 必须阻止
+## 进阶能力
 
-- `<think>` 或 `<analysis>` 推理标签；
-- Unicode 替换字符、NUL 或常见真实密钥格式；
-- secret、token、password、cookie、credential、API key 类配置字段；
-- 非法或冲突的重复 ID；
-- 笔记、内容哈希或批准文件被修改；
-- 已入库 ID 的内容变化；
-- 未登记但同名且内容冲突的笔记。
+只有用户明确要求本地转录、MiniMax、其他模型、飞书通知、局部批准、JSON 导入或 adapter 调试时，才展开高级配置。
 
-不要为了自动化继续运行而把这些错误降级为警告。
+- 默认轻量配置不下载模型、不要求 MiniMax；
+- 模型名按用户电脑实际能力配置；
+- 凭据只从环境变量、系统钥匙串或 Secret Manager 读取；
+- 当前仓库不内置视频下载器、模型安装器、MiniMax 客户端或飞书机器人；
+- 转录、分析和通知通过 `module:function` adapter 接入。
+
+原子命令 `scan -> review -> promote` 保留给局部审核和调试。批准必须明确；不得为了自动化把哈希、重复 ID、敏感信息或冲突文件错误降级为警告。
 
 ## 验证
 
@@ -97,4 +78,4 @@ python3 -m compileall -q src tests
 PYTHONPATH=src python3 -m unittest discover -s tests -v
 ```
 
-fixture 成功只证明事务和浏览器编排契约；真实采集仍依赖有效的授权登录和抖音当前页面结构。
+真实采集依赖有效的授权登录和抖音当前页面结构。fixture 通过只证明事务与编排契约。

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -14,6 +14,14 @@ description: 将用户已授权账号中的抖音收藏，通过本地浏览器�
 
 MiniMax 不是必需项。本地模型名称因电脑而异，必须以用户实际可用模型为准。`provider` 记录选择，`adapter` 执行调用；不要声称仓库会自动下载视频、安装模型或配置飞书。
 
+首次安装时引导用户复制 `config/config.example.json` 为 `config/config.local.json`，只修改知识库路径，然后先运行：
+
+```bash
+douyin-favorites-knowledge --config config/config.local.json check-config
+```
+
+只有输出 `status: valid` 且 `mode: light` 后，才继续登录和首次扫描。提醒用户 `--config` 必须放在子命令前。完整模式应在轻量模式成功入库后再配置。
+
 ## 前置边界
 
 - 用户有权访问来源收藏，采集方式符合平台条款和当地法律。

--- a/skill/agents/openai.yaml
+++ b/skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Douyin Favorites to Knowledge"
-  short_description: "Sync signed-in Douyin favorites into reviewed local notes"
-  default_prompt: "Use $douyin-favorites-to-knowledge to sign in locally, scan my authorized favorites, review them, and promote approved notes without exposing cookies."
+  display_name: "抖音收藏转本地知识库"
+  short_description: "登录抖音后增量整理收藏，并按需接入转录、分析与通知"
+  default_prompt: "使用 $douyin-favorites-to-knowledge 登录我的抖音账号，扫描新增收藏，审核后写入本地知识库；需要时再选择本地模型、MiniMax 或通知 adapter。"

--- a/skill/agents/openai.yaml
+++ b/skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "抖音收藏转本地知识库"
-  short_description: "登录抖音后增量整理收藏，并按需接入转录、分析与通知"
-  default_prompt: "使用 $douyin-favorites-to-knowledge 登录我的抖音账号，扫描新增收藏，审核后写入本地知识库；需要时再选择本地模型、MiniMax 或通知 adapter。"
+  short_description: "首次配置后，一条命令把新增抖音收藏同步到本地知识库"
+  default_prompt: "使用 $douyin-favorites-to-knowledge 帮我完成首次配置，并把新增抖音收藏同步到本地知识库。"

--- a/src/douyin_favorites_knowledge/__init__.py
+++ b/src/douyin_favorites_knowledge/__init__.py
@@ -1,3 +1,3 @@
 """Public core for reviewed Douyin-favorite knowledge promotion."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/src/douyin_favorites_knowledge/cli.py
+++ b/src/douyin_favorites_knowledge/cli.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import argparse
 import json
-import sqlite3
 import sys
 from pathlib import Path
 
 from .adapters import load_adapter
 from .browser_collector import browser_status, collect_browser_favorites, login_browser, logout_browser
-from .config import load_config
+from .config import Config, StageConfig, load_config
 from .security import safe_error_message
 from .workflow import (
     atomic_write_json,
@@ -22,7 +21,7 @@ from .workflow import (
 
 def parser() -> argparse.ArgumentParser:
     root = argparse.ArgumentParser(description="Promote reviewed Douyin favorites into local knowledge notes")
-    root.add_argument("--config", type=Path, help="Path to schema_version=1 JSON config")
+    root.add_argument("--config", type=Path, help="Path to schema_version=1 or 2 JSON config")
     commands = root.add_subparsers(dest="command", required=True)
 
     login = commands.add_parser("login", help="Open a local browser and save an authorized session")
@@ -69,6 +68,35 @@ def _print(payload: dict) -> None:
     print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
 
 
+def _apply_enricher(raw_items: list[dict], spec: str, context: dict) -> list[dict]:
+    enricher = load_adapter(spec)
+    enriched = []
+    for raw in raw_items:
+        if not isinstance(raw, dict):
+            raise ValueError("each source item must be an object before enrichment")
+        update = enricher(dict(raw), dict(context))
+        if not isinstance(update, dict):
+            raise ValueError("enricher must return an object")
+        if "aweme_id" in update and str(update["aweme_id"]) != str(raw.get("aweme_id", "")):
+            raise ValueError("enricher cannot change aweme_id")
+        update.pop("source_url", None)
+        enriched.append({**raw, **update})
+    return enriched
+
+
+def _apply_configured_stages(raw_items: list[dict], config: Config) -> list[dict]:
+    for stage in config.enrichment_stages():
+        raw_items = _apply_enricher(raw_items, stage.adapter, stage.context(config.mode))
+    return raw_items
+
+
+def _configured_notifier(config: Config) -> tuple[str, dict] | None:
+    stage: StageConfig = config.notification
+    if not stage.enabled:
+        return None
+    return stage.adapter, stage.context(config.mode)
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parser().parse_args(argv)
     try:
@@ -104,15 +132,9 @@ def main(argv: list[str] | None = None) -> int:
                     channel=args.browser_channel,
                 )
                 default_source_label = "authorized_browser"
+            raw_items = _apply_configured_stages(list(raw_items), config)
             if args.enricher:
-                enricher = load_adapter(args.enricher)
-                enriched = []
-                for raw in raw_items:
-                    update = enricher(dict(raw), dict(config.raw))
-                    if not isinstance(update, dict):
-                        raise ValueError("enricher must return an object")
-                    enriched.append({**raw, **update})
-                raw_items = enriched
+                raw_items = _apply_enricher(raw_items, args.enricher, dict(config.raw))
             manifest = build_review(config, raw_items, args.source_label or default_source_label)
             result = {"status": "valid", **manifest["summary"], "review": str(args.review)}
             if not args.dry_run:
@@ -145,13 +167,16 @@ def main(argv: list[str] | None = None) -> int:
 
         result = promote(config, args.review, args.approval, dry_run=args.dry_run)
         result["status"] = "valid" if args.dry_run else "committed"
-        if args.notifier and not args.dry_run and result["promoted_count"]:
-            notifier = load_adapter(args.notifier)
-            notifier(dict(result), dict(config.raw))
+        configured = _configured_notifier(config)
+        notifier_spec = args.notifier or (configured[0] if configured else "")
+        notifier_context = dict(config.raw) if args.notifier else (configured[1] if configured else {})
+        if notifier_spec and not args.dry_run and result["promoted_count"]:
+            notifier = load_adapter(notifier_spec)
+            notifier(dict(result), notifier_context)
             result["notification"] = "sent"
         _print(result)
         return 0
-    except (ImportError, AttributeError, OSError, ValueError, sqlite3.Error) as exc:
+    except Exception as exc:
         print(f"ERROR: {safe_error_message(exc)}", file=sys.stderr)
         return 1
 

--- a/src/douyin_favorites_knowledge/cli.py
+++ b/src/douyin_favorites_knowledge/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from .adapters import load_adapter
 from .browser_collector import browser_status, collect_browser_favorites, login_browser, logout_browser
-from .config import Config, StageConfig, load_config
+from .config import Config, StageConfig, default_config_path, load_config
 from .security import safe_error_message
 from .workflow import (
     atomic_write_json,
@@ -21,8 +21,15 @@ from .workflow import (
 
 def parser() -> argparse.ArgumentParser:
     root = argparse.ArgumentParser(description="将审核通过的抖音收藏写入本地知识库")
-    root.add_argument("--config", type=Path, help="schema_version 为 1 或 2 的 JSON 配置路径")
+    root.add_argument("--config", type=Path, help="可选配置路径；setup 后通常不需要填写")
     commands = root.add_subparsers(dest="command", required=True)
+
+    setup = commands.add_parser("setup", help="完成首次配置并登录抖音")
+    setup.add_argument("--knowledge-dir", type=Path, help="Markdown 或 Obsidian 知识库目录")
+    setup.add_argument("--skip-login", action="store_true", help="只创建配置，暂不打开登录页")
+    setup.add_argument("--force", action="store_true", help="覆盖已有配置并重新选择知识库")
+    setup.add_argument("--timeout", type=int, default=300, help="等待登录的秒数")
+    setup.add_argument("--browser-channel", help="Playwright 浏览器通道，如 chrome 或 msedge")
 
     login = commands.add_parser("login", help="打开本地浏览器并保存授权登录状态")
     login.add_argument("--timeout", type=int, default=300, help="等待登录的秒数")
@@ -35,6 +42,14 @@ def parser() -> argparse.ArgumentParser:
     logout.add_argument("--browser-channel", help="Playwright 浏览器通道，如 chrome 或 msedge")
 
     commands.add_parser("check-config", help="检查配置并显示已启用模式，不输出敏感信息")
+
+    sync = commands.add_parser("sync", help="扫描新增收藏，确认后写入知识库")
+    sync.add_argument("--yes", action="store_true", help="明确批准本次全部新增，适合自动任务")
+    sync.add_argument("--max-items", type=int, default=200, help="浏览器单次最多采集条数")
+    sync.add_argument("--headed", action="store_true", help="采集时保持浏览器可见")
+    sync.add_argument("--no-login-prompt", action="store_true", help="登录失效时直接失败，不打开登录页")
+    sync.add_argument("--browser-channel", help="Playwright 浏览器通道，如 chrome 或 msedge")
+    sync.add_argument("--dry-run", action="store_true", help="只显示新增候选，不写入知识库")
 
     scan = commands.add_parser("scan", help="生成待审核清单，不修改知识库")
     source = scan.add_mutually_exclusive_group()
@@ -85,6 +100,46 @@ def _config_summary(config: Config) -> dict:
     }
 
 
+def _light_config_payload(config_path: Path, knowledge_dir: Path) -> dict:
+    return {
+        "schema_version": 2,
+        "mode": "light",
+        "knowledge_dir": str(knowledge_dir.expanduser().resolve()),
+        "ledger_path": str((config_path.parent / "state" / "ledger.sqlite3").resolve()),
+        "transcription": {"enabled": False, "provider": "none"},
+        "analysis": {"enabled": False, "provider": "none"},
+        "notification": {"enabled": False, "provider": "none"},
+    }
+
+
+def _setup(args: argparse.Namespace) -> int:
+    config_path = (args.config or default_config_path()).expanduser().resolve()
+    if config_path.exists() and not args.force:
+        if args.knowledge_dir is not None:
+            raise ValueError("配置已存在；更换知识库目录请使用 setup --force")
+        load_config(config_path)
+    else:
+        default_knowledge = Path.home() / "Douyin Knowledge"
+        knowledge_dir = args.knowledge_dir
+        if knowledge_dir is None:
+            try:
+                answer = input(f"知识库目录 [{default_knowledge}]: ").strip()
+            except EOFError as exc:
+                raise ValueError("非交互安装请使用 setup --knowledge-dir 指定知识库目录") from exc
+            knowledge_dir = Path(answer).expanduser() if answer else default_knowledge
+        atomic_write_json(config_path, _light_config_payload(config_path, knowledge_dir))
+        load_config(config_path)
+
+    login_status = "skipped"
+    if not args.skip_login:
+        login_status = login_browser(
+            timeout_seconds=args.timeout,
+            channel=args.browser_channel,
+        )["status"]
+    _print({"status": "ready", "login": login_status})
+    return 0
+
+
 def _apply_enricher(raw_items: list[dict], spec: str, context: dict) -> list[dict]:
     enricher = load_adapter(spec)
     enriched = []
@@ -114,9 +169,77 @@ def _configured_notifier(config: Config) -> tuple[str, dict] | None:
     return stage.adapter, stage.context(config.mode)
 
 
+def _notify_if_configured(config: Config, result: dict) -> None:
+    configured = _configured_notifier(config)
+    if not configured or not result["promoted_count"]:
+        return
+    notifier = load_adapter(configured[0])
+    notifier(dict(result), configured[1])
+    result["notification"] = "sent"
+
+
+def _sync(args: argparse.Namespace, config: Config) -> int:
+    raw_items = collect_browser_favorites(
+        max_items=args.max_items,
+        interactive_login=not args.no_login_prompt,
+        headed=args.headed,
+        channel=args.browser_channel,
+    )
+    raw_items = _apply_configured_stages(list(raw_items), config)
+    manifest = build_review(config, raw_items, "authorized_browser")
+    candidates = manifest["items"]
+    if not candidates:
+        _print({"status": "no_changes"})
+        return 0
+
+    preview = [
+        {"aweme_id": item["aweme_id"], "title": item["title"][:120]}
+        for item in candidates[:20]
+    ]
+    if args.dry_run:
+        _print({"status": "review_required", **manifest["summary"], "preview": preview})
+        return 0
+
+    if not args.yes:
+        print(f"发现 {len(candidates)} 条新增收藏：")
+        for item in preview:
+            print(f"- {item['aweme_id']}  {item['title']}")
+        if len(candidates) > len(preview):
+            print(f"- 以及另外 {len(candidates) - len(preview)} 条")
+        try:
+            answer = input("确认写入知识库？[y/N]: ").strip().lower()
+        except EOFError as exc:
+            raise ValueError("非交互同步请明确使用 sync --yes 或 sync --dry-run") from exc
+        if answer not in {"y", "yes"}:
+            _print({"status": "cancelled", "candidate_count": len(candidates)})
+            return 0
+
+    runtime_dir = config.ledger_path.parent / "sync"
+    review_path = runtime_dir / "review.json"
+    approval_path = runtime_dir / "approval.json"
+    atomic_write_json(review_path, manifest)
+    approval = build_approval(review_path, [item["aweme_id"] for item in candidates])
+    atomic_write_json(approval_path, approval)
+    result = promote(config, review_path, approval_path)
+    result["status"] = "committed"
+    _notify_if_configured(config, result)
+    summary = {
+        "status": result["status"],
+        "promoted_count": result["promoted_count"],
+        "skipped_count": result["skipped_count"],
+    }
+    if "notification" in result:
+        summary["notification"] = result["notification"]
+    _print(summary)
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parser().parse_args(argv)
     try:
+        if args.command == "setup":
+            return _setup(args)
+
         if args.command == "login":
             _print(login_browser(timeout_seconds=args.timeout, channel=args.browser_channel))
             return 0
@@ -130,12 +253,15 @@ def main(argv: list[str] | None = None) -> int:
             _print(logout_browser(channel=args.browser_channel))
             return 0
 
-        if args.config is None:
-            raise ValueError(f"--config is required for {args.command}")
-        config = load_config(args.config)
+        config_path = (args.config or default_config_path()).expanduser().resolve()
+        if not config_path.exists():
+            raise ValueError("尚未完成配置，请先运行 douyin-favorites-knowledge setup")
+        config = load_config(config_path)
         if args.command == "check-config":
             _print(_config_summary(config))
             return 0
+        if args.command == "sync":
+            return _sync(args, config)
         if args.command == "scan":
             if args.input:
                 raw_items = read_input(args.input)

--- a/src/douyin_favorites_knowledge/cli.py
+++ b/src/douyin_favorites_knowledge/cli.py
@@ -20,52 +20,69 @@ from .workflow import (
 
 
 def parser() -> argparse.ArgumentParser:
-    root = argparse.ArgumentParser(description="Promote reviewed Douyin favorites into local knowledge notes")
-    root.add_argument("--config", type=Path, help="Path to schema_version=1 or 2 JSON config")
+    root = argparse.ArgumentParser(description="将审核通过的抖音收藏写入本地知识库")
+    root.add_argument("--config", type=Path, help="schema_version 为 1 或 2 的 JSON 配置路径")
     commands = root.add_subparsers(dest="command", required=True)
 
-    login = commands.add_parser("login", help="Open a local browser and save an authorized session")
-    login.add_argument("--timeout", type=int, default=300, help="Seconds to wait for login")
-    login.add_argument("--browser-channel", help="Playwright channel such as chrome or msedge")
+    login = commands.add_parser("login", help="打开本地浏览器并保存授权登录状态")
+    login.add_argument("--timeout", type=int, default=300, help="等待登录的秒数")
+    login.add_argument("--browser-channel", help="Playwright 浏览器通道，如 chrome 或 msedge")
 
-    status = commands.add_parser("status", help="Check the saved browser session without exposing it")
-    status.add_argument("--browser-channel", help="Playwright channel such as chrome or msedge")
+    status = commands.add_parser("status", help="检查已保存的浏览器登录状态，不输出会话内容")
+    status.add_argument("--browser-channel", help="Playwright 浏览器通道，如 chrome 或 msedge")
 
-    logout = commands.add_parser("logout", help="Clear the locally saved Douyin browser session")
-    logout.add_argument("--browser-channel", help="Playwright channel such as chrome or msedge")
+    logout = commands.add_parser("logout", help="清除本地保存的抖音浏览器会话")
+    logout.add_argument("--browser-channel", help="Playwright 浏览器通道，如 chrome 或 msedge")
 
-    scan = commands.add_parser("scan", help="Create a non-mutating review manifest")
+    commands.add_parser("check-config", help="检查配置并显示已启用模式，不输出敏感信息")
+
+    scan = commands.add_parser("scan", help="生成待审核清单，不修改知识库")
     source = scan.add_mutually_exclusive_group()
-    source.add_argument("--input", type=Path, help="JSON list or object containing items")
-    source.add_argument("--collector", help="Collector adapter in module:function format")
-    source.add_argument("--browser", action="store_true", help="Use the built-in authorized browser collector")
-    scan.add_argument("--enricher", help="Optional per-item enricher adapter in module:function format")
-    scan.add_argument("--source-label", help="Non-sensitive source label stored in the manifest")
-    scan.add_argument("--review", type=Path, required=True, help="Review manifest output")
-    scan.add_argument("--max-items", type=int, default=200, help="Maximum browser items to collect")
-    scan.add_argument("--headed", action="store_true", help="Keep the collection browser visible")
-    scan.add_argument("--no-login-prompt", action="store_true", help="Fail instead of opening login")
-    scan.add_argument("--browser-channel", help="Playwright channel such as chrome or msedge")
-    scan.add_argument("--dry-run", action="store_true", help="Validate and summarize without writing")
+    source.add_argument("--input", type=Path, help="包含收藏条目的 JSON 列表或对象")
+    source.add_argument("--collector", help="module:function 格式的 collector adapter")
+    source.add_argument("--browser", action="store_true", help="使用内置授权浏览器 collector")
+    scan.add_argument("--enricher", help="可选的单条内容增强 adapter，格式为 module:function")
+    scan.add_argument("--source-label", help="写入审核清单的非敏感来源标签")
+    scan.add_argument("--review", type=Path, required=True, help="待审核清单输出路径")
+    scan.add_argument("--max-items", type=int, default=200, help="浏览器单次最多采集条数")
+    scan.add_argument("--headed", action="store_true", help="采集时保持浏览器可见")
+    scan.add_argument("--no-login-prompt", action="store_true", help="登录失效时直接失败，不打开登录页")
+    scan.add_argument("--browser-channel", help="Playwright 浏览器通道，如 chrome 或 msedge")
+    scan.add_argument("--dry-run", action="store_true", help="只校验和汇总，不写入文件")
 
-    review = commands.add_parser("review", help="Validate a review and optionally create explicit approval")
+    review = commands.add_parser("review", help="校验待审核清单，并按明确选择生成批准文件")
     review.add_argument("--review", type=Path, required=True)
     review.add_argument("--approval", type=Path)
     selection = review.add_mutually_exclusive_group()
     selection.add_argument("--approve-all", action="store_true")
     selection.add_argument("--approve", action="append", default=[], metavar="AWEME_ID")
-    review.add_argument("--dry-run", action="store_true", help="Validate selection without writing approval")
+    review.add_argument("--dry-run", action="store_true", help="只校验批准选择，不写入批准文件")
 
-    promote_cmd = commands.add_parser("promote", help="Atomically write approved notes and ledger entries")
+    promote_cmd = commands.add_parser("promote", help="原子写入已批准笔记和防重账本")
     promote_cmd.add_argument("--review", type=Path, required=True)
     promote_cmd.add_argument("--approval", type=Path, required=True)
-    promote_cmd.add_argument("--notifier", help="Optional post-commit notifier in module:function format")
-    promote_cmd.add_argument("--dry-run", action="store_true", help="Validate transaction without writing")
+    promote_cmd.add_argument("--notifier", help="提交后可选通知 adapter，格式为 module:function")
+    promote_cmd.add_argument("--dry-run", action="store_true", help="只校验事务，不写入知识库")
     return root
 
 
 def _print(payload: dict) -> None:
     print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+def _config_summary(config: Config) -> dict:
+    stages = {}
+    for stage in (config.transcription, config.analysis, config.notification):
+        status = {"enabled": stage.enabled, "provider": stage.provider}
+        if stage.model:
+            status["model"] = stage.model
+        stages[stage.name] = status
+    return {
+        "status": "valid",
+        "schema_version": config.raw["schema_version"],
+        "mode": config.mode,
+        "stages": stages,
+    }
 
 
 def _apply_enricher(raw_items: list[dict], spec: str, context: dict) -> list[dict]:
@@ -116,6 +133,9 @@ def main(argv: list[str] | None = None) -> int:
         if args.config is None:
             raise ValueError(f"--config is required for {args.command}")
         config = load_config(args.config)
+        if args.command == "check-config":
+            _print(_config_summary(config))
+            return 0
         if args.command == "scan":
             if args.input:
                 raw_items = read_input(args.input)

--- a/src/douyin_favorites_knowledge/config.py
+++ b/src/douyin_favorites_knowledge/config.py
@@ -9,10 +9,89 @@ from .security import assert_safe_value
 
 
 @dataclass(frozen=True)
+class StageConfig:
+    name: str
+    enabled: bool
+    provider: str
+    adapter: str
+    model: str
+    options: dict[str, Any]
+
+    def context(self, mode: str) -> dict[str, Any]:
+        return {
+            "mode": mode,
+            "stage": self.name,
+            "provider": self.provider,
+            "model": self.model,
+            "options": dict(self.options),
+        }
+
+
+@dataclass(frozen=True)
 class Config:
     knowledge_dir: Path
     ledger_path: Path
+    mode: str
+    transcription: StageConfig
+    analysis: StageConfig
+    notification: StageConfig
     raw: dict[str, Any]
+
+    def enrichment_stages(self) -> tuple[StageConfig, ...]:
+        return tuple(stage for stage in (self.transcription, self.analysis) if stage.enabled)
+
+
+STAGE_PROVIDERS = {
+    "transcription": {"none", "local", "adapter"},
+    "analysis": {"none", "local", "minimax", "adapter"},
+    "notification": {"none", "feishu", "adapter"},
+}
+
+
+def _stage_config(raw: dict[str, Any], name: str) -> StageConfig:
+    value = raw.get(name, {})
+    if not isinstance(value, dict):
+        raise ValueError(f"config {name} must be an object")
+    if name in raw:
+        missing = {"enabled", "provider"} - set(value)
+        if missing:
+            raise ValueError(f"missing config fields at {name}: {sorted(missing)}")
+    allowed = {"enabled", "provider", "adapter", "model", "options"}
+    unknown = set(value) - allowed
+    if unknown:
+        raise ValueError(f"unknown config fields at {name}: {sorted(unknown)}")
+
+    enabled = value.get("enabled", False)
+    provider = value.get("provider", "none")
+    adapter = value.get("adapter", "")
+    model = value.get("model", "")
+    options = value.get("options", {})
+    if not isinstance(enabled, bool):
+        raise ValueError(f"config {name}.enabled must be a boolean")
+    if not isinstance(provider, str) or provider not in STAGE_PROVIDERS[name]:
+        raise ValueError(f"unsupported {name} provider: {provider!r}")
+    if not isinstance(adapter, str) or (adapter and ":" not in adapter):
+        raise ValueError(f"config {name}.adapter must use module:function format")
+    if not isinstance(model, str):
+        raise ValueError(f"config {name}.model must be a string")
+    if not isinstance(options, dict):
+        raise ValueError(f"config {name}.options must be an object")
+    if enabled and provider == "none":
+        raise ValueError(f"config {name}.provider cannot be none when enabled")
+    if enabled and not adapter:
+        raise ValueError(f"config {name}.adapter is required when enabled")
+    if not enabled and (provider != "none" or adapter or model or options):
+        raise ValueError(f"disabled config {name} must not define provider settings")
+    if enabled and provider in {"local", "minimax"} and not model.strip():
+        raise ValueError(f"config {name}.model is required for provider {provider}")
+    return StageConfig(
+        name=name,
+        enabled=enabled,
+        provider=provider,
+        adapter=adapter,
+        model=model.strip(),
+        options=dict(options),
+    )
 
 
 def load_config(path: Path) -> Config:
@@ -20,10 +99,15 @@ def load_config(path: Path) -> Config:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise ValueError(f"cannot read config: {exc}") from exc
-    if not isinstance(raw, dict) or raw.get("schema_version") != 1:
-        raise ValueError("config schema_version must be 1")
+    if not isinstance(raw, dict):
+        raise ValueError("config must be an object")
+    version = raw.get("schema_version")
+    if isinstance(version, bool) or not isinstance(version, int) or version not in {1, 2}:
+        raise ValueError("config schema_version must be 1 or 2")
     assert_safe_value(raw, "config")
     allowed = {"schema_version", "knowledge_dir", "ledger_path"}
+    if version == 2:
+        allowed.update({"mode", "transcription", "analysis", "notification"})
     unknown = set(raw) - allowed
     if unknown:
         raise ValueError(f"unknown config fields: {sorted(unknown)}")
@@ -41,4 +125,22 @@ def load_config(path: Path) -> Config:
     ledger_path = resolve(raw["ledger_path"])
     if knowledge_dir == ledger_path:
         raise ValueError("knowledge_dir and ledger_path must be different")
-    return Config(knowledge_dir=knowledge_dir, ledger_path=ledger_path, raw=dict(raw))
+
+    mode = "light" if version == 1 else raw.get("mode", "light")
+    if not isinstance(mode, str) or mode not in {"light", "full"}:
+        raise ValueError("config mode must be light or full")
+    stages = {
+        name: _stage_config(raw if version == 2 else {}, name)
+        for name in STAGE_PROVIDERS
+    }
+    if mode == "light" and any(stage.enabled for stage in stages.values()):
+        raise ValueError("light mode cannot enable optional stages")
+    return Config(
+        knowledge_dir=knowledge_dir,
+        ledger_path=ledger_path,
+        mode=mode,
+        transcription=stages["transcription"],
+        analysis=stages["analysis"],
+        notification=stages["notification"],
+        raw=dict(raw),
+    )

--- a/src/douyin_favorites_knowledge/config.py
+++ b/src/douyin_favorites_knowledge/config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import platform
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -46,6 +48,20 @@ STAGE_PROVIDERS = {
     "analysis": {"none", "local", "minimax", "adapter"},
     "notification": {"none", "feishu", "adapter"},
 }
+
+
+def default_config_path() -> Path:
+    override = os.environ.get("DOUYIN_FAVORITES_CONFIG")
+    if override:
+        return Path(override).expanduser().resolve()
+    system = platform.system()
+    if system == "Darwin":
+        root = Path.home() / "Library" / "Application Support"
+    elif system == "Windows":
+        root = Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming"))
+    else:
+        root = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    return root / "douyin-favorites-to-knowledge" / "config.json"
 
 
 def _stage_config(raw: dict[str, Any], name: str) -> StageConfig:

--- a/src/douyin_favorites_knowledge/security.py
+++ b/src/douyin_favorites_knowledge/security.py
@@ -12,7 +12,10 @@ BLOCKED_PATTERNS = {
     "Apify token": re.compile(r"apify_api_[A-Za-z0-9_-]{20,}"),
 }
 
-SECRET_KEY = re.compile(r"(?:token|secret|password|cookie|credential|api[_-]?key)", re.IGNORECASE)
+SECRET_KEY = re.compile(
+    r"(?:token|secret|password|cookie|credential|api[_-]?key|access[_-]?key|private[_-]?key|authorization)",
+    re.IGNORECASE,
+)
 PRIVATE_PATH = re.compile(r"(?:/Users/|/home/)[^\s:]+")
 
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -10,9 +10,9 @@ TEXT_SUFFIXES = {".md", ".py", ".json", ".yml", ".yaml", ".toml", ".txt"}
 class RepositoryTests(unittest.TestCase):
     def test_version_is_current_release(self):
         text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
-        self.assertIn('version = "1.1.0"', text)
+        self.assertIn('version = "1.2.0"', text)
         package = (ROOT / "src" / "douyin_favorites_knowledge" / "__init__.py").read_text(encoding="utf-8")
-        self.assertIn('__version__ = "1.1.0"', package)
+        self.assertIn('__version__ = "1.2.0"', package)
 
     def test_skill_frontmatter(self):
         text = (ROOT / "skill" / "SKILL.md").read_text(encoding="utf-8")

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -18,6 +18,7 @@ sys.path.insert(0, PYTHONPATH)
 
 from douyin_favorites_knowledge.security import safe_error_message  # noqa: E402
 from douyin_favorites_knowledge.cli import main  # noqa: E402
+from douyin_favorites_knowledge.config import load_config  # noqa: E402
 
 
 def cli(config: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -269,6 +270,220 @@ class WorkflowTests(unittest.TestCase):
         result = self.scan()
         self.assertEqual(result.returncode, 1)
         self.assertIn("secret-like key blocked", result.stderr)
+
+    def test_schema_v1_config_remains_light_mode_compatible(self):
+        config = load_config(self.config)
+        self.assertEqual(config.mode, "light")
+        self.assertEqual(config.enrichment_stages(), ())
+        self.assertFalse(config.notification.enabled)
+
+    def test_full_mode_runs_configured_stages_in_order(self):
+        self.config.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "mode": "full",
+                    "knowledge_dir": "knowledge",
+                    "ledger_path": "state/ledger.sqlite3",
+                    "transcription": {
+                        "enabled": True,
+                        "provider": "local",
+                        "adapter": "example.pipeline:transcribe",
+                        "model": "user-selected-asr",
+                    },
+                    "analysis": {
+                        "enabled": True,
+                        "provider": "minimax",
+                        "adapter": "example.pipeline:analyze",
+                        "model": "user-selected-analysis-model",
+                    },
+                    "notification": {"enabled": False, "provider": "none"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        calls = []
+
+        def load(spec):
+            if spec.endswith(":transcribe"):
+                def transcribe(item, context):
+                    calls.append((context["stage"], context["provider"], context["model"]))
+                    return {"transcript": "本地转录结果"}
+
+                return transcribe
+
+            def analyze(item, context):
+                calls.append((context["stage"], context["provider"], context["model"]))
+                self.assertEqual(item["transcript"], "本地转录结果")
+                return {"tags": ["自动分析"]}
+
+            return analyze
+
+        output = StringIO()
+        with patch("douyin_favorites_knowledge.cli.load_adapter", side_effect=load), redirect_stdout(output):
+            returncode = main(
+                [
+                    "--config",
+                    str(self.config),
+                    "scan",
+                    "--input",
+                    str(FIXTURE),
+                    "--review",
+                    str(self.review),
+                ]
+            )
+        self.assertEqual(returncode, 0)
+        self.assertEqual(
+            calls,
+            [
+                ("transcription", "local", "user-selected-asr"),
+                ("transcription", "local", "user-selected-asr"),
+                ("analysis", "minimax", "user-selected-analysis-model"),
+                ("analysis", "minimax", "user-selected-analysis-model"),
+            ],
+        )
+        review = json.loads(self.review.read_text(encoding="utf-8"))
+        self.assertEqual(review["items"][0]["transcript"], "本地转录结果")
+        self.assertEqual(review["items"][0]["tags"], ["自动分析"])
+
+    def test_light_mode_rejects_enabled_optional_stage(self):
+        self.config.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "mode": "light",
+                    "knowledge_dir": "knowledge",
+                    "ledger_path": "state/ledger.sqlite3",
+                    "analysis": {
+                        "enabled": True,
+                        "provider": "adapter",
+                        "adapter": "example.pipeline:analyze",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = self.scan()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("light mode cannot enable optional stages", result.stderr)
+
+    def test_provider_credentials_cannot_be_written_to_config(self):
+        self.config.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "mode": "full",
+                    "knowledge_dir": "knowledge",
+                    "ledger_path": "state/ledger.sqlite3",
+                    "analysis": {
+                        "enabled": True,
+                        "provider": "minimax",
+                        "adapter": "example.pipeline:analyze",
+                        "model": "example-model",
+                        "options": {"api_key": "placeholder"},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = self.scan()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("secret-like key blocked", result.stderr)
+
+    def test_invalid_provider_type_is_reported_without_traceback(self):
+        self.config.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "mode": "full",
+                    "knowledge_dir": "knowledge",
+                    "ledger_path": "state/ledger.sqlite3",
+                    "analysis": {"enabled": True, "provider": ["minimax"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = self.scan()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("unsupported analysis provider", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_invalid_schema_version_type_is_reported_without_traceback(self):
+        payload = json.loads(self.config.read_text(encoding="utf-8"))
+        payload["schema_version"] = [2]
+        self.config.write_text(json.dumps(payload), encoding="utf-8")
+        result = self.scan()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("schema_version must be 1 or 2", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_adapter_runtime_error_is_redacted(self):
+        token = "sk-" + "A" * 24
+        output = StringIO()
+        errors = StringIO()
+        with patch(
+            "douyin_favorites_knowledge.cli.load_adapter",
+            return_value=lambda item, context: (_ for _ in ()).throw(RuntimeError(token)),
+        ), redirect_stdout(output), patch("sys.stderr", errors):
+            returncode = main(
+                [
+                    "--config",
+                    str(self.config),
+                    "scan",
+                    "--input",
+                    str(FIXTURE),
+                    "--enricher",
+                    "example.pipeline:enrich",
+                    "--review",
+                    str(self.review),
+                ]
+            )
+        self.assertEqual(returncode, 1)
+        self.assertNotIn(token, errors.getvalue())
+        self.assertIn("[REDACTED]", errors.getvalue())
+        self.assertFalse(self.review.exists())
+
+    def test_configured_notifier_receives_stage_context(self):
+        self.config.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "mode": "full",
+                    "knowledge_dir": "knowledge",
+                    "ledger_path": "state/ledger.sqlite3",
+                    "notification": {
+                        "enabled": True,
+                        "provider": "feishu",
+                        "adapter": "example.pipeline:notify",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.assertEqual(self.scan().returncode, 0)
+        self.assertEqual(self.approve().returncode, 0)
+        seen = []
+
+        def notifier(event, context):
+            seen.append((event["promoted_count"], context))
+
+        output = StringIO()
+        with patch("douyin_favorites_knowledge.cli.load_adapter", return_value=notifier), redirect_stdout(output):
+            returncode = main(
+                [
+                    "--config",
+                    str(self.config),
+                    "promote",
+                    "--review",
+                    str(self.review),
+                    "--approval",
+                    str(self.approval),
+                ]
+            )
+        self.assertEqual(returncode, 0)
+        self.assertEqual(seen[0][0], 2)
+        self.assertEqual(seen[0][1]["stage"], "notification")
+        self.assertEqual(seen[0][1]["provider"], "feishu")
 
     def test_concurrent_promotions_serialize(self):
         self.assertEqual(self.scan().returncode, 0)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -18,7 +18,7 @@ sys.path.insert(0, PYTHONPATH)
 
 from douyin_favorites_knowledge.security import safe_error_message  # noqa: E402
 from douyin_favorites_knowledge.cli import main  # noqa: E402
-from douyin_favorites_knowledge.config import load_config  # noqa: E402
+from douyin_favorites_knowledge.config import default_config_path, load_config  # noqa: E402
 
 
 def cli(config: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -294,6 +294,169 @@ class WorkflowTests(unittest.TestCase):
         )
         self.assertNotIn(str(self.root), result.stdout)
         self.assertNotIn("ledger.sqlite3", result.stdout)
+
+    def test_default_config_path_honors_environment_override(self):
+        custom = self.root / "app-config.json"
+        with patch.dict(os.environ, {"DOUYIN_FAVORITES_CONFIG": str(custom)}):
+            self.assertEqual(default_config_path(), custom.resolve())
+
+    def test_setup_creates_safe_light_config_without_login(self):
+        setup_config = self.root / "app" / "config.json"
+        output = StringIO()
+        with redirect_stdout(output):
+            returncode = main(
+                [
+                    "--config",
+                    str(setup_config),
+                    "setup",
+                    "--knowledge-dir",
+                    str(self.knowledge),
+                    "--skip-login",
+                ]
+            )
+        self.assertEqual(returncode, 0)
+        payload = json.loads(setup_config.read_text(encoding="utf-8"))
+        self.assertEqual(payload["mode"], "light")
+        self.assertEqual(payload["knowledge_dir"], str(self.knowledge.resolve()))
+        self.assertNotIn("cookie", setup_config.read_text(encoding="utf-8").lower())
+        result = json.loads(output.getvalue())
+        self.assertEqual(result["status"], "ready")
+        self.assertEqual(result["login"], "skipped")
+        self.assertNotIn(str(self.root), output.getvalue())
+
+    def test_setup_opens_login_by_default(self):
+        setup_config = self.root / "login-setup" / "config.json"
+        output = StringIO()
+        with patch(
+            "douyin_favorites_knowledge.cli.login_browser",
+            return_value={"status": "authenticated"},
+        ) as login, redirect_stdout(output):
+            returncode = main(
+                [
+                    "--config",
+                    str(setup_config),
+                    "setup",
+                    "--knowledge-dir",
+                    str(self.knowledge),
+                ]
+            )
+        self.assertEqual(returncode, 0)
+        login.assert_called_once_with(timeout_seconds=300, channel=None)
+        self.assertEqual(json.loads(output.getvalue())["login"], "authenticated")
+
+    def test_setup_uses_default_config_for_followup_commands(self):
+        setup_config = self.root / "default" / "config.json"
+        with patch.dict(os.environ, {"DOUYIN_FAVORITES_CONFIG": str(setup_config)}):
+            output = StringIO()
+            with redirect_stdout(output):
+                setup_code = main(
+                    [
+                        "setup",
+                        "--knowledge-dir",
+                        str(self.knowledge),
+                        "--skip-login",
+                    ]
+                )
+            self.assertEqual(setup_code, 0)
+            output = StringIO()
+            with redirect_stdout(output):
+                check_code = main(["check-config"])
+        self.assertEqual(check_code, 0)
+        self.assertEqual(json.loads(output.getvalue())["mode"], "light")
+
+    def test_setup_does_not_silently_ignore_new_directory(self):
+        output = StringIO()
+        errors = StringIO()
+        with redirect_stdout(output), patch("sys.stderr", errors):
+            returncode = main(
+                [
+                    "--config",
+                    str(self.config),
+                    "setup",
+                    "--knowledge-dir",
+                    str(self.root / "another-knowledge"),
+                    "--skip-login",
+                ]
+            )
+        self.assertEqual(returncode, 1)
+        self.assertIn("setup --force", errors.getvalue())
+        self.assertFalse((self.root / "another-knowledge").exists())
+
+    def test_sync_previews_and_promotes_after_confirmation(self):
+        source_items = json.loads(FIXTURE.read_text(encoding="utf-8"))["items"]
+        output = StringIO()
+        with patch(
+            "douyin_favorites_knowledge.cli.collect_browser_favorites",
+            return_value=source_items,
+        ), patch("builtins.input", return_value="y") as prompt, redirect_stdout(output):
+            returncode = main(["--config", str(self.config), "sync"])
+        self.assertEqual(returncode, 0)
+        prompt.assert_called_once_with("确认写入知识库？[y/N]: ")
+        self.assertIn("发现 2 条新增收藏", output.getvalue())
+        result = json.loads(output.getvalue().splitlines()[-1])
+        self.assertEqual(result["status"], "committed")
+        self.assertEqual(result["promoted_count"], 2)
+        self.assertEqual(len(list(self.knowledge.glob("*.md"))), 2)
+
+    def test_sync_cancel_keeps_knowledge_and_ledger_untouched(self):
+        source_items = json.loads(FIXTURE.read_text(encoding="utf-8"))["items"]
+        output = StringIO()
+        with patch(
+            "douyin_favorites_knowledge.cli.collect_browser_favorites",
+            return_value=source_items,
+        ), patch("builtins.input", return_value="n"), redirect_stdout(output):
+            returncode = main(["--config", str(self.config), "sync"])
+        self.assertEqual(returncode, 0)
+        self.assertEqual(json.loads(output.getvalue().splitlines()[-1])["status"], "cancelled")
+        self.assertFalse(self.knowledge.exists())
+        self.assertFalse(self.ledger.exists())
+
+    def test_sync_yes_supports_noninteractive_automation(self):
+        source_items = json.loads(FIXTURE.read_text(encoding="utf-8"))["items"]
+        output = StringIO()
+        with patch(
+            "douyin_favorites_knowledge.cli.collect_browser_favorites",
+            return_value=source_items,
+        ), patch("builtins.input") as prompt, redirect_stdout(output):
+            returncode = main(["--config", str(self.config), "sync", "--yes"])
+        self.assertEqual(returncode, 0)
+        prompt.assert_not_called()
+        result = json.loads(output.getvalue())
+        self.assertEqual(result["status"], "committed")
+        self.assertEqual(result["promoted_count"], 2)
+
+    def test_sync_reports_no_changes_after_same_items_are_committed(self):
+        source_items = json.loads(FIXTURE.read_text(encoding="utf-8"))["items"]
+        with patch(
+            "douyin_favorites_knowledge.cli.collect_browser_favorites",
+            return_value=source_items,
+        ), redirect_stdout(StringIO()):
+            self.assertEqual(main(["--config", str(self.config), "sync", "--yes"]), 0)
+        output = StringIO()
+        with patch(
+            "douyin_favorites_knowledge.cli.collect_browser_favorites",
+            return_value=source_items,
+        ), redirect_stdout(output):
+            returncode = main(["--config", str(self.config), "sync", "--yes"])
+        self.assertEqual(returncode, 0)
+        result = json.loads(output.getvalue())
+        self.assertEqual(result["status"], "no_changes")
+        self.assertEqual(result, {"status": "no_changes"})
+
+    def test_sync_dry_run_writes_nothing(self):
+        source_items = json.loads(FIXTURE.read_text(encoding="utf-8"))["items"]
+        output = StringIO()
+        with patch(
+            "douyin_favorites_knowledge.cli.collect_browser_favorites",
+            return_value=source_items,
+        ), redirect_stdout(output):
+            returncode = main(["--config", str(self.config), "sync", "--dry-run"])
+        self.assertEqual(returncode, 0)
+        result = json.loads(output.getvalue())
+        self.assertEqual(result["status"], "review_required")
+        self.assertEqual(len(result["preview"]), 2)
+        self.assertFalse(self.knowledge.exists())
+        self.assertFalse(self.ledger.exists())
 
     def test_full_mode_runs_configured_stages_in_order(self):
         self.config.write_text(

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -277,6 +277,24 @@ class WorkflowTests(unittest.TestCase):
         self.assertEqual(config.enrichment_stages(), ())
         self.assertFalse(config.notification.enabled)
 
+    def test_check_config_guides_setup_without_exposing_local_paths(self):
+        result = cli(self.config, "check-config")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "valid")
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["mode"], "light")
+        self.assertEqual(
+            payload["stages"],
+            {
+                "analysis": {"enabled": False, "provider": "none"},
+                "notification": {"enabled": False, "provider": "none"},
+                "transcription": {"enabled": False, "provider": "none"},
+            },
+        )
+        self.assertNotIn(str(self.root), result.stdout)
+        self.assertNotIn("ledger.sqlite3", result.stdout)
+
     def test_full_mode_runs_configured_stages_in_order(self):
         self.config.write_text(
             json.dumps(


### PR DESCRIPTION
## 改动

- 将 README、Skill 说明和界面元数据改为中文。
- 新增兼容 v1 的配置 v2，支持 `light` 与 `full` 两种模式。
- 将本地转录、本地分析、MiniMax、飞书和其他实现统一为可选 adapter，不绑定特定电脑或模型。
- 配置文件继续拒绝 Cookie、API key、token、密码和其他凭据字段。
- 完整模式按 `transcription -> analysis -> promote -> notification` 调度，命令行 adapter 保持兼容。
- 补全 Git/ZIP 下载、macOS/Linux/Windows 虚拟环境、配置复制、登录、首次入库和验收标志。
- 新增 `check-config` 自检命令，只显示模式、阶段与模型，不输出本机路径、adapter 或凭据。
- 增加中文 CLI 帮助、常见问题表和完整模式启用前检查。
- 将公开主线收敛为 `setup -> sync`：首次配置自动生成安全默认配置并登录，日常同步先展示新增再等待确认。
- 默认配置存放在系统应用目录，普通用户不再复制或编辑 JSON；自动任务必须显式使用 `sync --yes --no-login-prompt`。
- README 首屏只保留一个仓库链接和两条主命令，模式、provider、adapter 与原子事务下沉到进阶章节。
- 版本更新为 1.2.0，并补充配置兼容、provider 调度、异常脱敏和通知测试。

## 原因

旧页面只有安全核心链路，但没有正式表达轻量模式与可选扩展的边界，容易让使用者误以为必须安装某个本地模型，或者误以为 MiniMax、视频下载和飞书已经内置。本次把真实能力、扩展方式和安全边界统一到代码、Schema 和中文文档中。

## 验证

- `python3 -m compileall -q src tests`
- `PYTHONPATH=src python3 -m unittest discover -s tests -v`：40 项通过
- `quick_validate.py skill`：通过
- Draft 2020-12 JSON Schema：v1、v2 合法样例通过，非法模式与缺失模型样例被拒绝
- 私有路径与常见密钥扫描：通过
- wheel 构建：通过
- 全新虚拟环境 simple-flow E2E：wheel 安装、`setup --skip-login`、默认配置发现、`check-config`、fixture 扫描、批准和 dry-run 入库通过
