### PR TITLE
[codex] 国内下载与 Agent 安装入口

### DIFF
--- a/.github/workflows/sync-gitee.yml
+++ b/.github/workflows/sync-gitee.yml
@@ -1,0 +1,39 @@
+name: Sync to Gitee
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-gitee
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Configure SSH
+        env:
+          GITEE_SSH_PRIVATE_KEY: ${{ secrets.GITEE_SSH_PRIVATE_KEY }}
+        run: |
+          test -n "$GITEE_SSH_PRIVATE_KEY"
+          install -m 700 -d "$HOME/.ssh"
+          printf '%s\n' "$GITEE_SSH_PRIVATE_KEY" > "$HOME/.ssh/gitee_mirror"
+          chmod 600 "$HOME/.ssh/gitee_mirror"
+          printf '%s\n' 'gitee.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEKxHSJ7084RmkJ4YdEi5tngynE8aZe2uEoVVsB/OvYN' > "$HOME/.ssh/known_hosts"
+      - name: Sync main and release tags
+        env:
+          GIT_SSH_COMMAND: ssh -i ~/.ssh/gitee_mirror -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes
+        run: |
+          git fetch --force origin refs/heads/main:refs/remotes/origin/main --tags
+          git remote add gitee git@gitee.com:tars123/douyin-favorites-to-knowledge.git
+          git push gitee refs/remotes/origin/main:refs/heads/main
+          git push gitee --tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.1 - 2026-07-28
+
+- 增加 ClawHub 的 Agent 安装入口和 Gitee 国内下载入口。
+- Skill 在缺少命令时优先引导 Agent 从 Gitee 安装完整程序。
+- 增加 GitHub `main` 与正式标签到 Gitee 的自动同步。
+
 ## 1.1.0 - 2026-07-25
 
 - Adds a built-in Playwright collector for the signed-in user's Douyin favorites.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,26 @@
 
 ## 最短使用路径
 
-安装：
+### 交给 Agent
+
+支持 ClawHub 的 Agent 可以直接安装 Skill：
 
 ```bash
-git clone https://github.com/tars1230/douyin-favorites-to-knowledge.git
+clawhub install douyin-favorites-to-knowledge
+```
+
+然后告诉 Agent：
+
+```text
+把我的抖音收藏同步到本地 Markdown 知识库。先使用默认轻量配置，不要让我复制 Cookie。
+```
+
+Agent 会在缺少程序时从国内镜像完成安装，并运行 `setup`。你只需要确认知识库目录，再在抖音官方页面正常登录。
+
+### 手动安装
+
+```bash
+git clone https://gitee.com/tars123/douyin-favorites-to-knowledge.git
 cd douyin-favorites-to-knowledge
 python3 -m venv .venv
 . .venv/bin/activate
@@ -36,16 +52,7 @@ douyin-favorites-knowledge sync
 
 命令会列出本次新增收藏。输入 `y` 后才会写入知识库；输入其他内容会取消，不改任何文件。
 
-## 让 AI 帮你安装
-
-把下面这句话发给 Codex、Claude Code 或其他能够操作本机项目的编程 Agent：
-
-```text
-请安装并配置这个项目：https://github.com/tars1230/douyin-favorites-to-knowledge
-把我的抖音收藏同步到本地 Markdown 知识库。先使用默认轻量配置，不要让我复制 Cookie。
-```
-
-Agent 应当完成安装并运行 `setup`。你只需要确认知识库目录，并在抖音官方页面登录。
+[GitHub](https://github.com/tars1230/douyin-favorites-to-knowledge) 保存源码、版本和问题反馈；[Gitee](https://gitee.com/tars123/douyin-favorites-to-knowledge) 提供国内下载，并自动同步 `main` 与正式标签。
 
 ## 安装说明
 
@@ -69,7 +76,7 @@ py -3 -m venv .venv
 python -m pip install .
 ```
 
-没有 Git 时，可以在 GitHub 页面点击 **Code -> Download ZIP**，解压后进入项目目录。
+没有 Git 时，可以在 Gitee 页面选择 **克隆/下载 -> 下载 ZIP**，解压后进入项目目录。
 
 系统会优先使用 Chrome 或 Edge。两者都没有时运行：
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "douyin-favorites-to-knowledge"
-version = "1.2.0"
+version = "1.2.1"
 description = "Authorized Douyin favorites collection with optional transcription and analysis adapters"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -9,7 +9,25 @@ description: 将用户已授权账号中的抖音收藏配置并同步到本地 
 
 ## 首次使用
 
-确认仓库已经安装后运行：
+先检查命令是否存在：
+
+```bash
+douyin-favorites-knowledge --help
+```
+
+如果命令不存在，优先从国内镜像安装完整程序。选择用户确认的项目目录，不要替用户猜测长期存放位置：
+
+```bash
+git clone https://gitee.com/tars123/douyin-favorites-to-knowledge.git
+cd douyin-favorites-to-knowledge
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install .
+```
+
+Gitee 不可用时再使用源码仓库 `https://github.com/tars1230/douyin-favorites-to-knowledge`。不要使用不明 GitHub 加速站。
+
+安装完成后运行：
 
 ```bash
 douyin-favorites-knowledge setup

--- a/src/douyin_favorites_knowledge/__init__.py
+++ b/src/douyin_favorites_knowledge/__init__.py
@@ -1,3 +1,3 @@
 """Public core for reviewed Douyin-favorite knowledge promotion."""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -10,9 +10,12 @@ TEXT_SUFFIXES = {".md", ".py", ".json", ".yml", ".yaml", ".toml", ".txt"}
 class RepositoryTests(unittest.TestCase):
     def test_version_is_current_release(self):
         text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
-        self.assertIn('version = "1.2.0"', text)
+        project_version = re.search(r'(?m)^version = "([^"]+)"$', text)
         package = (ROOT / "src" / "douyin_favorites_knowledge" / "__init__.py").read_text(encoding="utf-8")
-        self.assertIn('__version__ = "1.2.0"', package)
+        package_version = re.search(r'(?m)^__version__ = "([^"]+)"$', package)
+        self.assertIsNotNone(project_version)
+        self.assertIsNotNone(package_version)
+        self.assertEqual(project_version.group(1), package_version.group(1))
 
     def test_skill_frontmatter(self):
         text = (ROOT / "skill" / "SKILL.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## 变更

- 增加 ClawHub Agent 安装入口与 Gitee 国内手动下载入口
- Skill 在命令缺失时优先从 Gitee 安装完整程序
- 增加 GitHub `main` 与正式标签到 Gitee 的自动同步
- 将发布版本更新为 `1.2.1`，并让版本测试校验两处声明一致

## 原因

国内用户直接访问 GitHub 经常失败。Gitee 承接下载，ClawHub 承接 Agent 安装，GitHub 继续保存源码、版本与问题反馈。

## 验证

- 40 项 Python 单元与 fixture E2E 测试通过
- Skill quick validation 通过
- workflow YAML 解析与 `git diff --check` 通过
- wheel 构建、全新虚拟环境安装及版本检查通过
- Gitee SSH 主机指纹与官方文档一致
- Gitee `main` 和正式标签首次推送成功，公开 HTTPS SHA 与 GitHub 一致
