### PR TITLE
[codex] 说明当前可用的国内安装入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,13 @@
 
 ### 交给 Agent
 
-支持 ClawHub 的 Agent 可以直接安装 Skill：
-
-```bash
-clawhub install douyin-favorites-to-knowledge
-```
-
-然后告诉 Agent：
+把下面这句话发给 Codex、Claude Code、OpenClaw 等 Agent：
 
 ```text
-把我的抖音收藏同步到本地 Markdown 知识库。先使用默认轻量配置，不要让我复制 Cookie。
+请从 https://gitee.com/tars123/douyin-favorites-to-knowledge 安装“抖音收藏转本地知识库”，引导我完成首次设置，并把新增收藏同步到我的 Markdown 或 Obsidian 知识库。先使用默认轻量配置，不要让我复制 Cookie。
 ```
 
-Agent 会在缺少程序时从国内镜像完成安装，并运行 `setup`。你只需要确认知识库目录，再在抖音官方页面正常登录。
+你只需要确认知识库目录，再在抖音官方页面正常登录。ClawHub 一键安装正在等待平台发布审核；审核通过前请使用上面的 Gitee 地址。
 
 ### 手动安装
 


### PR DESCRIPTION
## 改了什么

- 首页改为直接把 Gitee 安装指令交给 Agent
- 明确 ClawHub 当前仍在等待平台发布审核
- 保留手动安装与 GitHub 源码入口

## 为什么

ClawHub 扫描结果为 CLEAN，但仍处于 `pending.publication`，目前无法公开安装。首页不应把暂不可用的命令描述为已可用。

## 验证

- 40 项单元测试通过
- `compileall` 通过
- `git diff --check` 通过
