### PR TITLE
[codex] 恢复已验证的 ClawHub 一键安装

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,19 @@
 
 ### 交给 Agent
 
-把下面这句话发给 Codex、Claude Code、OpenClaw 等 Agent：
+支持 ClawHub 的 Agent 先运行：
 
-```text
-请从 https://gitee.com/tars123/douyin-favorites-to-knowledge 安装“抖音收藏转本地知识库”，引导我完成首次设置，并把新增收藏同步到我的 Markdown 或 Obsidian 知识库。先使用默认轻量配置，不要让我复制 Cookie。
+```bash
+clawhub install douyin-favorites-to-knowledge
 ```
 
-你只需要确认知识库目录，再在抖音官方页面正常登录。ClawHub 一键安装正在等待平台发布审核；审核通过前请使用上面的 Gitee 地址。
+然后告诉 Agent：
+
+```text
+把我的抖音收藏同步到本地 Markdown 或 Obsidian 知识库。先使用默认轻量配置，不要让我复制 Cookie。
+```
+
+Agent 会在缺少程序时优先从 Gitee 安装完整程序。你只需要确认知识库目录，再在抖音官方页面正常登录。
 
 ### 手动安装
 


### PR DESCRIPTION
## 改了什么

- 恢复 ClawHub 一键安装为 Agent 的最短路径
- 明确完整程序会优先从 Gitee 国内镜像安装
- 保留 Gitee 手动安装入口

## 验证

- 在全新临时目录执行 `clawhub install douyin-favorites-to-knowledge` 成功
- 实际安装版本为 `1.2.1`
- 安装后的 `SKILL.md` 与 GitHub 文件 SHA-256 一致
- ClawHub 公开页面返回 200
- 40 项单元测试、`compileall`、`git diff --check` 通过
