### PR TITLE
fix: make skill compatible with SkillHub upload

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: douyin-favorites-to-knowledge
+version: 1.2.1
 description: 将用户已授权账号中的抖音收藏配置并同步到本地 Markdown 或 Obsidian 知识库；提供首次 setup、增量 sync、登录恢复、JSON 导入、局部审核，以及按需接入本地转录、MiniMax 或其他分析模型和飞书通知。不得绕过登录、访问他人账号或泄露 Cookie 与私密数据。
 ---
 

--- a/skill/agents/openai.yaml
+++ b/skill/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "抖音收藏转本地知识库"
-  short_description: "首次配置后，一条命令把新增抖音收藏同步到本地知识库"
-  default_prompt: "使用 $douyin-favorites-to-knowledge 帮我完成首次配置，并把新增抖音收藏同步到本地知识库。"


### PR DESCRIPTION
## Why

SkillHub 的官方上传器不接受可选的 OpenAI UI YAML 元数据；缺少 version 字段时，平台会默认登记为 1.0.0。

## Changes

- 移除不属于核心能力的 skill/agents/openai.yaml
- 在 skill/SKILL.md 声明现有公开发行版本 1.2.1

## Verification

- PYTHONPATH=src python3 -m unittest discover -s tests -v：40 passed
- 官方 skillhub-upload publish dry-run 通过，包含原创来源和四个内容标签