### PR TITLE
fix(asr): video/play-only path, drop audio_url prefer (2.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Changelog
+
+## [2.2.4] - 2026-08-05
+
+### Changed
+- ASR 简化为单一稳定路径：只下 `play_url`/`video_url` → ffmpeg 抽音 → SenseVoice；去掉 `audio_url` 优先分支。
+
+## [2.2.3] - 2026-08-05
+
+### Changed
+- ASR：优先 `audio_url`，失败回退 `play_url`；`DOUYIN_ASR_AUDIO_BITRATE` / `DOUYIN_ASR_SAMPLE_RATE` 可配。
+- 采集：仅原创音/视频音轨写入 `audio_url`，避免 BGM 误转写。
+
 ## [2.2.2] - 2026-08-05
 
 ### Changed
@@ -8,14 +21,6 @@
 ### Changed
 - 费用说明改为 SiliconFlow 默认：截至 2026-08-05 官方价格页 `FunAudioLLM/SenseVoiceSmall` 标注**免费**（会变，以 https://siliconflow.cn/pricing 与账单为准）。
 - 百炼 `0.00022 元/秒` 估算降为可选方案旁注，不再当默认报价。
-
-# Changelog
-
-## [2.2.3] - 2026-08-05
-
-### Changed
-- ASR：优先 `audio_url`，失败回退 `play_url`；`DOUYIN_ASR_AUDIO_BITRATE` / `DOUYIN_ASR_SAMPLE_RATE` 可配。
-- 采集：仅原创音/视频音轨写入 `audio_url`，避免 BGM 误转写。
 
 
 ## 2.2.0 — 2026-08-05

--- a/README.md
+++ b/README.md
@@ -397,9 +397,9 @@ python -m pip uninstall douyin-favorites-to-knowledge
 
 [MIT](LICENSE)
 
-### ASR 媒体与码率（2.2.3+）
-- 下载优先 `audio_url`（采集端仅在原创音/视频音轨时填充），失败回退 `play_url` 视频。
-- **注意**：抖音 `music.play_url` 经常是 BGM 不是口播，不能无脑当音频源。
+### ASR 媒体与码率（2.2.4+）
+- **单一路径**：下载 `play_url`/`video_url` → `ffmpeg -vn` 抽音 → 上传 SenseVoice。
+- **不再优先** `audio_url`（抖音 `music.play_url` 经常是 BGM 不是口播）。
 - 环境变量：`DOUYIN_ASR_AUDIO_BITRATE`（默认 `64k`）、`DOUYIN_ASR_SAMPLE_RATE`（默认 `16000`）。
-- 网络下载阶段仍可能是视频体积；上传给 SenseVoice 的是抽好的小音频。
+- 网络下载阶段可能是视频体积；上传给 SenseVoice 的是抽好的小音频。
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -147,9 +147,9 @@ PYTHONPATH=src python3 -m unittest discover -s tests -v
 
 抖音默认 **SiliconFlow SenseVoice**（本机 Referer 下载上传）。百炼 URL-ASR 对 douyinvod 常失败，仅可选。密钥：`SILICONFLOW_API_KEY`。
 
-### ASR 媒体与码率（2.2.3+）
-- 下载优先 `audio_url`（采集端仅在原创音/视频音轨时填充），失败回退 `play_url` 视频。
-- **注意**：抖音 `music.play_url` 经常是 BGM 不是口播，不能无脑当音频源。
+### ASR 媒体与码率（2.2.4+）
+- **单一路径**：下载 `play_url`/`video_url` → `ffmpeg -vn` 抽音 → 上传 SenseVoice。
+- **不再优先** `audio_url`（抖音 `music.play_url` 经常是 BGM 不是口播）。
 - 环境变量：`DOUYIN_ASR_AUDIO_BITRATE`（默认 `64k`）、`DOUYIN_ASR_SAMPLE_RATE`（默认 `16000`）。
-- 网络下载阶段仍可能是视频体积；上传给 SenseVoice 的是抽好的小音频。
+- 网络下载阶段可能是视频体积；上传给 SenseVoice 的是抽好的小音频。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "douyin-favorites-to-knowledge"
-version = "2.2.3"
+version = "2.2.4"
 description = "Authorized Douyin favorites collection with optional transcription and analysis adapters"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -147,9 +147,9 @@ PYTHONPATH=src python3 -m unittest discover -s tests -v
 
 抖音默认 **SiliconFlow SenseVoice**（本机 Referer 下载上传）。百炼 URL-ASR 对 douyinvod 常失败，仅可选。密钥：`SILICONFLOW_API_KEY`。
 
-### ASR 媒体与码率（2.2.3+）
-- 下载优先 `audio_url`（采集端仅在原创音/视频音轨时填充），失败回退 `play_url` 视频。
-- **注意**：抖音 `music.play_url` 经常是 BGM 不是口播，不能无脑当音频源。
+### ASR 媒体与码率（2.2.4+）
+- **单一路径**：下载 `play_url`/`video_url` → `ffmpeg -vn` 抽音 → 上传 SenseVoice。
+- **不再优先** `audio_url`（抖音 `music.play_url` 经常是 BGM 不是口播）。
 - 环境变量：`DOUYIN_ASR_AUDIO_BITRATE`（默认 `64k`）、`DOUYIN_ASR_SAMPLE_RATE`（默认 `16000`）。
-- 网络下载阶段仍可能是视频体积；上传给 SenseVoice 的是抽好的小音频。
+- 网络下载阶段可能是视频体积；上传给 SenseVoice 的是抽好的小音频。
 

--- a/src/douyin_favorites_knowledge/__init__.py
+++ b/src/douyin_favorites_knowledge/__init__.py
@@ -1,3 +1,3 @@
 """Public core for silent Douyin-favorite knowledge synchronization."""
 
-__version__ = "2.2.3"
+__version__ = "2.2.4"

--- a/src/douyin_favorites_knowledge/local_whisper.py
+++ b/src/douyin_favorites_knowledge/local_whisper.py
@@ -59,7 +59,8 @@ def _sample_rate() -> str:
 def _candidate_urls(item: dict[str, Any]) -> list[str]:
     seen: set[str] = set()
     out: list[str] = []
-    for key in ("audio_url", "play_url", "video_url"):
+    # Video/play only — skip audio_url (often commercial BGM, not speech).
+    for key in ("play_url", "video_url"):
         url = str(item.get(key) or "").strip()
         if url and url not in seen:
             seen.add(url)
@@ -113,7 +114,7 @@ def _download(url: str, destination: Path, max_media_bytes: int) -> str | None:
 
 
 def transcribe(item: dict[str, Any], context: dict[str, Any]) -> dict[str, str]:
-    """Download authorized media (audio preferred), extract audio, transcribe locally."""
+    """Download authorized play/video media, extract audio, transcribe locally."""
     readiness = check_environment()
     if not readiness["ready"]:
         raise ValueError(f"local Whisper transcription is not ready: {', '.join(readiness['missing'])}")

--- a/src/douyin_favorites_knowledge/siliconflow.py
+++ b/src/douyin_favorites_knowledge/siliconflow.py
@@ -3,13 +3,15 @@
 
 Douyin ``*.douyinvod.com`` play URLs require browser-like Referer headers and
 cannot be fetched by Bailian server-side URL-ASR. This provider downloads with
-Referer, optionally extracts audio via ffmpeg, and uploads to SiliconFlow.
+Referer, extracts audio via ffmpeg, and uploads to SiliconFlow.
 
-Media selection:
-1. Prefer ``audio_url`` when present (may be smaller).
-2. Fall back to ``play_url`` / video if audio missing, download fails, or ASR empty.
-Note: Douyin ``music.play_url`` is often BGM, not speech — collectors should only
-populate audio_url when it is likely original/speech audio; we still fall back.
+Stable path (deliberately simple):
+1. Download ``play_url`` / ``video_url`` (video stream).
+2. ``ffmpeg -vn`` extract mono 16 kHz mp3.
+3. Upload to SiliconFlow SenseVoice.
+
+Do **not** prefer ``audio_url`` / ``music.play_url`` — that is often commercial
+BGM, not speech, and adds a flaky branch. Keep one media path.
 """
 from __future__ import annotations
 
@@ -74,11 +76,10 @@ def _looks_like_audio_url(url: str) -> bool:
 
 
 def _candidate_urls(item: dict[str, Any]) -> list[tuple[str, str]]:
-    """Ordered (kind, url) candidates: audio first, then video/play."""
+    """Ordered (kind, url) candidates: video/play only (no audio_url branch)."""
     seen: set[str] = set()
     out: list[tuple[str, str]] = []
     for kind, key in (
-        ("audio", "audio_url"),
         ("play", "play_url"),
         ("video", "video_url"),
     ):
@@ -206,7 +207,7 @@ def _upload_transcribe(path: Path, api_key: str, model: str, endpoint: str) -> s
 
 
 def transcribe(item: dict[str, Any], context: dict[str, Any]) -> dict[str, str]:
-    """Download media with Referer (audio preferred) and transcribe via SiliconFlow."""
+    """Download video/play with Referer, extract audio, transcribe via SiliconFlow."""
     readiness = check_environment()
     if not readiness["ready"]:
         raise ValueError(f"SiliconFlow transcription is not ready: {', '.join(readiness['missing'])}")

--- a/tests/test_siliconflow.py
+++ b/tests/test_siliconflow.py
@@ -86,8 +86,8 @@ class LocalWhisperRefererTests(unittest.TestCase):
         self.assertIn("douyin.com", headers["referer"])
 
 
-class SiliconFlowAudioFirstTests(unittest.TestCase):
-    def test_prefers_audio_url_before_play_url(self):
+class SiliconFlowVideoPathTests(unittest.TestCase):
+    def test_uses_play_url_and_ignores_audio_url(self):
         order = []
 
         def fake_download(url, destination, max_bytes):
@@ -96,8 +96,7 @@ class SiliconFlowAudioFirstTests(unittest.TestCase):
             return None
 
         def fake_upload(path, api_key, model, endpoint):
-            # succeed only for audio candidate path content after extract skip
-            return "来自音频轨"
+            return "来自视频轨"
 
         with patch.dict(os.environ, {"SILICONFLOW_API_KEY": "sf-key", "DOUYIN_ASR_AUDIO_BITRATE": "48k"}, clear=True), patch(
             "douyin_favorites_knowledge.siliconflow._download_media", side_effect=fake_download
@@ -114,12 +113,13 @@ class SiliconFlowAudioFirstTests(unittest.TestCase):
                 {},
             )
         self.assertEqual(result["transcript_status"], "success")
-        self.assertEqual(order[0], "https://cdn.example/a.m4a")
-        self.assertEqual(result.get("media_kind_used"), "audio")
+        self.assertEqual(order, ["https://v3-web.douyinvod.com/big.mp4"])
+        self.assertEqual(result.get("media_kind_used"), "play")
+        self.assertEqual(result["transcript"], "来自视频轨")
 
-    def test_falls_back_to_play_url_when_audio_fails(self):
+    def test_falls_back_to_video_url_when_play_fails(self):
         def fake_download(url, destination, max_bytes):
-            if url.endswith(".m4a"):
+            if "play" in url or url.endswith("big.mp4"):
                 return "failed"
             destination.write_bytes(b"video-bytes")
             return None
@@ -135,12 +135,13 @@ class SiliconFlowAudioFirstTests(unittest.TestCase):
                 {
                     "audio_url": "https://cdn.example/a.m4a",
                     "play_url": "https://v3-web.douyinvod.com/big.mp4",
+                    "video_url": "https://cdn.example/alt.mp4",
                 },
                 {},
             )
         self.assertEqual(result["transcript_status"], "success")
         self.assertEqual(result["transcript"], "视频回退成功")
-        self.assertEqual(result.get("media_kind_used"), "play")
+        self.assertEqual(result.get("media_kind_used"), "video")
 
     def test_bitrate_env_passed_to_ffmpeg(self):
         seen = {}


### PR DESCRIPTION
## Summary
- ASR 单一路径：`play_url`/`video_url` → ffmpeg → SenseVoice
- 忽略 `audio_url`（BGM 风险）
- tests + docs + 2.2.4

## Test plan
- [x] PYTHONPATH=src pytest 70 passed
- [x] SF canary extract+upload OK