### PR TITLE
chore(release): v2.2.5 SiliconFlow setup guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.5] - 2026-08-05
+
+### Changed
+- setup / next_step 缺 SiliconFlow Key 时强制给出推荐注册页 + 控制台 + export 三步；交互终端可打开 `https://cloud.siliconflow.cn/i/1srulim9`。
+
 ## [2.2.4] - 2026-08-05
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -86,8 +86,13 @@ douyin-favorites-knowledge daily --source collection --no-login-prompt
 用户未指定时，建议 **SiliconFlow** 云端转录（`FunAudioLLM/SenseVoiceSmall`），并让用户在 `setup` 中明确选择。
 需要 `SILICONFLOW_API_KEY` 与可选 `ffmpeg`。
 
-- **注册推荐链接**：[https://cloud.siliconflow.cn/i/1srulim9](https://cloud.siliconflow.cn/i/1srulim9)
-- Key 控制台：[https://cloud.siliconflow.cn/account/ak](https://cloud.siliconflow.cn/account/ak)
+**新用户按序拿 Key（setup 缺 Key 时会打印同样步骤，交互可打开浏览器）：**
+
+1. 推荐注册/登录：https://cloud.siliconflow.cn/i/1srulim9  
+2. 控制台创建 Key：https://cloud.siliconflow.cn/account/ak  
+3. `export SILICONFLOW_API_KEY='…'` 或写入 `~/.hermes/.env`，**重启 Agent**  
+4. `douyin-favorites-knowledge check-config`
+
 抖音 CDN：本机用浏览器式 `Referer: https://www.douyin.com/` 临时下载已授权 `play_url` → 上传 SenseVoice → **立即删除临时文件**；不要把 douyinvod URL 丢给百炼服务端。
 密钥不能写入 config、笔记或日志。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "douyin-favorites-to-knowledge"
-version = "2.2.4"
+version = "2.2.5"
 description = "Authorized Douyin favorites collection with optional transcription and analysis adapters"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -86,8 +86,13 @@ douyin-favorites-knowledge daily --source collection --no-login-prompt
 用户未指定时，建议 **SiliconFlow** 云端转录（`FunAudioLLM/SenseVoiceSmall`），并让用户在 `setup` 中明确选择。
 需要 `SILICONFLOW_API_KEY` 与可选 `ffmpeg`。
 
-- **注册推荐链接**：[https://cloud.siliconflow.cn/i/1srulim9](https://cloud.siliconflow.cn/i/1srulim9)
-- Key 控制台：[https://cloud.siliconflow.cn/account/ak](https://cloud.siliconflow.cn/account/ak)
+**新用户按序拿 Key（setup 缺 Key 时会打印同样步骤，交互可打开浏览器）：**
+
+1. 推荐注册/登录：https://cloud.siliconflow.cn/i/1srulim9  
+2. 控制台创建 Key：https://cloud.siliconflow.cn/account/ak  
+3. `export SILICONFLOW_API_KEY='…'` 或写入 `~/.hermes/.env`，**重启 Agent**  
+4. `douyin-favorites-knowledge check-config`
+
 抖音 CDN：本机用浏览器式 `Referer: https://www.douyin.com/` 临时下载已授权 `play_url` → 上传 SenseVoice → **立即删除临时文件**；不要把 douyinvod URL 丢给百炼服务端。
 密钥不能写入 config、笔记或日志。
 

--- a/src/douyin_favorites_knowledge/__init__.py
+++ b/src/douyin_favorites_knowledge/__init__.py
@@ -1,3 +1,3 @@
 """Public core for silent Douyin-favorite knowledge synchronization."""
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"

--- a/src/douyin_favorites_knowledge/cli.py
+++ b/src/douyin_favorites_knowledge/cli.py
@@ -184,11 +184,15 @@ def _transcription_next_step(transcription: str) -> str | None:
     if transcription == "siliconflow":
         readiness = check_siliconflow_environment()
         if not readiness["ready"]:
-            return "SiliconFlow 转录尚未就绪：设置 SILICONFLOW_API_KEY（https://cloud.siliconflow.cn/account/ak），然后执行 check-config。"
+            return (
+                "SiliconFlow 转录尚未就绪：① 打开推荐注册页 https://cloud.siliconflow.cn/i/1srulim9 "
+                "② 控制台创建 Key https://cloud.siliconflow.cn/account/ak "
+                "③ export SILICONFLOW_API_KEY='…'（或写入 ~/.hermes/.env）后执行 check-config。"
+            )
     if transcription == "bailian":
         readiness = check_bailian_environment()
         if not readiness["ready"]:
-            return "百炼转录尚未就绪：设置 DASHSCOPE_API_KEY，并运行 python -m pip install '.[bailian-asr]'，然后执行 check-config。注意：抖音 CDN 上百炼 URL-ASR 常失败，优先 SiliconFlow。"
+            return "百炼转录尚未就绪：设置 DASHSCOPE_API_KEY，并运行 python -m pip install '.[bailian-asr]'，然后执行 check-config。注意：抖音 CDN 上百炼 URL-ASR 常失败，优先 SiliconFlow（注册：https://cloud.siliconflow.cn/i/1srulim9）。"
     if transcription == "local":
         readiness = check_local_whisper_environment()
         if not readiness["ready"]:
@@ -313,13 +317,34 @@ def _setup(args: argparse.Namespace) -> int:
             channel=args.browser_channel,
         )["status"]
     next_step = _transcription_next_step(transcription)
-    _print({
+    payload = {
         "status": "ready",
         "login": login_status,
         "transcription": transcription,
         "provider_discovery": discover_providers(),
         **({"next_step": next_step} if next_step else {}),
-    })
+    }
+    if transcription == "siliconflow" and next_step:
+        payload["siliconflow_referral_url"] = "https://cloud.siliconflow.cn/i/1srulim9"
+        payload["siliconflow_console_url"] = "https://cloud.siliconflow.cn/account/ak"
+        if sys.stdin.isatty():
+            print("—— SiliconFlow 配置（抖音推荐）——", file=sys.stderr)
+            print("  ① 推荐注册/登录：https://cloud.siliconflow.cn/i/1srulim9", file=sys.stderr)
+            print("  ② 控制台建 Key：https://cloud.siliconflow.cn/account/ak", file=sys.stderr)
+            print("  ③ export SILICONFLOW_API_KEY='…' 或写入 ~/.hermes/.env 后重启", file=sys.stderr)
+            try:
+                ans = input("是否打开推荐注册页？[Y/n] ").strip().lower()
+            except EOFError:
+                ans = "n"
+            if ans not in {"n", "no"}:
+                try:
+                    import webbrowser
+
+                    webbrowser.open("https://cloud.siliconflow.cn/i/1srulim9")
+                    print("已尝试打开浏览器。", file=sys.stderr)
+                except Exception:
+                    print("无法自动打开，请手动访问推荐注册页。", file=sys.stderr)
+    _print(payload)
     return 0
 
 


### PR DESCRIPTION
## Summary
- next_step / interactive setup 含推荐注册页 + 可选浏览器打开
- skill/SKILL.md 新用户按序拿 Key

## Test plan
- [x] PYTHONPATH=src pytest